### PR TITLE
Fix #11 issue with canopy height

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,30 @@
 CHANGES
 =======
 
+* Update version
+* Get the pft\_params.nml file in run directory
+* Clarify instructions for run directory
+
+v0.1.3
+------
+
+* Update version
+* Fixes issue #1: missing line to subprocess
+
+v0.1.2
+------
+
+* Update README.md
+* Update README.md
+* Update README.md
+* Update README.md
+* Add file auto-created
+* Revised job size for better CPU utilisation
+* Correct PyYAML dependency for conda
+* Update version
+* Add yaml dependency for conda
+* Add dependencies for conda
+* Change to README
 * Update README
 * Use site data published in ks32
 * Add running the configurations

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 CHANGES
 =======
 
+* Changelog
 * Update version
 * Get the pft\_params.nml file in run directory
 * Clarify instructions for run directory

--- a/benchcab/run_cable_site.py
+++ b/benchcab/run_cable_site.py
@@ -39,6 +39,7 @@ class RunCableSite(object):
         aux_dir="",
         namelist_dir="",
         nml_fname="cable.nml",
+        veg_nml="pft_params.nml",
         veg_fname="def_veg_params_zr_clitt_albedo_fix.txt",
         soil_fname="def_soil_params.txt",
         grid_fname="gridinfo_CSIRO_1x1.nc",
@@ -76,12 +77,14 @@ class RunCableSite(object):
         self.met_subset = met_subset
         self.cable_src = cable_src
         self.cable_exe = os.path.join(cable_src, "offline/%s" % (cable_exe))
-        self.setup_exe()
+        self.veg_nml = Path(cable_src, f"offline/{veg_nml}")
         self.verbose = verbose
         self.lai_dir = lai_dir
         self.fixed_lai = fixed_lai
         self.num_cores = num_cores
         self.multiprocess = multiprocess
+
+        self.setup_from_source()
 
     def main(self, sci_config, repo_id, sci_id):
 
@@ -147,7 +150,7 @@ class RunCableSite(object):
             (out_fname, out_log_fname) = self.clean_up_old_files(site, repo_id, sci_id)
 
             # Add LAI to met file?
-            if self.fixed_lai is not None or self.lai_dir is not "":
+            if self.fixed_lai is not None or self.lai_dir != "":
                 fname = change_LAI(
                     fname, site, fixed=self.fixed_lai, lai_dir=self.lai_dir
                 )
@@ -173,21 +176,29 @@ class RunCableSite(object):
             adjust_nml_file(nml_fname, replace_dict)
 
             self.run_me(nml_fname)
-
+            
             add_attributes_to_output_file(nml_fname, out_fname, sci_config, url, rev)
             shutil.move(nml_fname, os.path.join(self.namelist_dir, nml_fname))
 
-            if self.fixed_lai is not None or self.lai_dir is not "":
+            if self.fixed_lai is not None or self.lai_dir != "":
                 os.remove("%s_tmp.nc" % (site))
 
-    def setup_exe(self):
+    def setup_from_source(self):
         # delete local executable, copy a local copy and use that
+        # Copy the pft params namelist from source code too.
         # local_exe = os.path.join(cwd, "cable")
         local_exe = "cable"
         if os.path.isfile(local_exe):
             os.remove(local_exe)
         if os.path.isfile(self.cable_exe):
             shutil.copy(self.cable_exe, local_exe)
+
+        local_nml = Path(self.veg_nml).name
+        if Path(local_nml).is_file():
+            os.remove(local_nml)
+        if Path(self.veg_nml).is_file():
+            shutil.copy(self.veg_nml, local_nml)
+        
         self.cable_exe = local_exe
 
     def initialise_stuff(self):

--- a/benchcab/run_cable_site.py
+++ b/benchcab/run_cable_site.py
@@ -40,6 +40,7 @@ class RunCableSite(object):
         namelist_dir="",
         nml_fname="cable.nml",
         veg_nml="pft_params.nml",
+        soil_nml="cable_soilparm.nml",
         veg_fname="def_veg_params_zr_clitt_albedo_fix.txt",
         soil_fname="def_soil_params.txt",
         grid_fname="gridinfo_CSIRO_1x1.nc",
@@ -78,6 +79,7 @@ class RunCableSite(object):
         self.cable_src = cable_src
         self.cable_exe = os.path.join(cable_src, "offline/%s" % (cable_exe))
         self.veg_nml = Path(cable_src, f"offline/{veg_nml}")
+        self.soil_nml = Path(cable_src, f"offline/{soil_nml}")
         self.verbose = verbose
         self.lai_dir = lai_dir
         self.fixed_lai = fixed_lai
@@ -183,23 +185,26 @@ class RunCableSite(object):
             if self.fixed_lai is not None or self.lai_dir != "":
                 os.remove("%s_tmp.nc" % (site))
 
-    def setup_from_source(self):
-        # delete local executable, copy a local copy and use that
-        # Copy the pft params namelist from source code too.
-        # local_exe = os.path.join(cwd, "cable")
-        local_exe = "cable"
-        if os.path.isfile(local_exe):
-            os.remove(local_exe)
-        if os.path.isfile(self.cable_exe):
-            shutil.copy(self.cable_exe, local_exe)
+    @staticmethod
+    def copy_files(copies):
+        # Copy file src to dst if src exist
+        # copies: Dict, mapping from source path to dest. path
+        for src, dst in copies.items():
+            if Path(src).is_file():
+                shutil.copy(src, dst)
 
-        local_nml = Path(self.veg_nml).name
-        if Path(local_nml).is_file():
-            os.remove(local_nml)
-        if Path(self.veg_nml).is_file():
-            shutil.copy(self.veg_nml, local_nml)
-        
-        self.cable_exe = local_exe
+    def setup_from_source(self):
+        # copy files needed to run cable in the run directory:
+        # - cable executable
+        # - veg. parameters namelist
+        # - soil parameters namelist
+        copies={
+            self.cable_exe:"cable",
+            self.veg_nml:Path(self.veg_nml).name,
+            self.soil_nml:Path(self.soil_nml).name,
+        }
+        self.copy_files(copies)
+        self.cable_exe = copies[self.cable_exe]
 
     def initialise_stuff(self):
 

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.1.3" %}
+{% set version = "0.1.4" %}
 
 package:
   name: benchcab

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name=benchcab
 summary= Software to run a benchmarking suite for CABLE LSM
-version=0.1.3
+version=0.1.4
 description=To benchmark CABLE simulations
 url=https://github.com/CABLE-LSM/benchcab
 author=Claire Carouge


### PR DESCRIPTION
It seems the code was not copying the new pft_params.nml file to the run/ directory so it didn't use the proper information for the vegetation.

Now when comparing 2 science configs with the trunk in modelevaluation.org, we get:

- differences between configs
- NEE not equal 0

See [results](https://modelevaluation.org/analyses/anywhere/fQ89uhxtF5b8yQ4kd/5TqGyBXuRFFMFiBed/WakeWp8Qt97y5s8Do/all)