### PR TITLE
Fix issue 13. Source namelist from a common directory

### DIFF
--- a/benchcab/benchtree.py
+++ b/benchcab/benchtree.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import os
+import shutil
 class BenchTree(object):
     """Manage the directory tree to run the benchmarking for CABLE"""
 
@@ -11,6 +12,7 @@ class BenchTree(object):
         # Run directory and its sub-directories
         self.runroot_dir = curdir/"runs"
         self.site_run = {
+            "site_dir": self.runroot_dir/"site",
             "log_dir": self.runroot_dir/"site/logs",
             "output_dir": self.runroot_dir/"site/outputs",
             "restart_dir": self.runroot_dir/"site/restart_files",
@@ -41,4 +43,13 @@ class BenchTree(object):
         for mydir in self.site_run.values():
             if not mydir.is_dir():
                 os.makedirs(mydir)
+
+        # Copy namelists from the namelists/ directory
+        nml_dir = Path.cwd()/"namelists"
+        try:
+            shutil.copytree(nml_dir,self.site_run["site_dir"],dirs_exist_ok=True)
+        except:
+            raise
+
+
     

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.1.4" %}
+{% set version = "0.1.5" %}
 
 package:
   name: benchcab

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name=benchcab
 summary= Software to run a benchmarking suite for CABLE LSM
-version=0.1.4
+version=0.1.5
 description=To benchmark CABLE simulations
 url=https://github.com/CABLE-LSM/benchcab
 author=Claire Carouge


### PR DESCRIPTION
Now the namelists will be sourced from a sub-directory in the work directory instead of CABLE-AUX or the source code. This will allow for changing the base namelists more easily.