### PR TITLE
Add revision number in branch description

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,17 @@
 CHANGES
 =======
 
+* Log last change revision number for each branch
+* Add rev. number in svn checkout and config.yaml
+* Remove code to create user copy of trunk
+* new version
+* Change source of namelist files Fixes #13
+* Need the soil namelist in the run dir
 * Changelog
+
+v0.1.4
+------
+
 * Update version
 * Get the pft\_params.nml file in run directory
 * Clarify instructions for run directory

--- a/benchcab/get_cable.py
+++ b/benchcab/get_cable.py
@@ -29,22 +29,27 @@ class GetCable(object):
         self.aux_dir = "CABLE-AUX"
         self.home_dir = os.environ["HOME"]
 
-    def main(self, name=None, trunk=False, share_branch=False):
+    def main(self, name=None, trunk=False, share_branch=False, revision=-1):
 
         self.initialise_stuff()
 
-        self.get_repo(name, trunk, share_branch)
+        self.get_repo(name, trunk, share_branch, revision)
 
     def initialise_stuff(self):
 
         if not os.path.exists(self.src_dir):
             os.makedirs(self.src_dir)
 
-    def get_repo(self, repo_name, trunk, share_branch):
+    def get_repo(self, repo_name, trunk, share_branch, revision):
 
         need_pass = False
         cwd = os.getcwd()
         os.chdir(self.src_dir)
+
+        # Check if a specified version is required. Negative value means take the latest
+        rev_opt=""
+        if revision > 0:
+            rev_opt=f"-r {revision}"
 
         try:
             where = os.listdir("%s/.subversion/auth/svn.simple/" % (self.home_dir))
@@ -59,12 +64,8 @@ class GetCable(object):
         if trunk:
 
             if need_pass:
-                cmd = "svn checkout %s/trunk --password %s" % (
-                    self.root,
-                    self.user,
-                    repo_name,
-                    pswd,
-                )
+                cmd = f"svn checkout {rev_opt} {self.root}/trunk --password {pswd}"
+
                 with tempfile.NamedTemporaryFile(mode="w+t") as f:
                     f.write(cmd)
                     f.flush()
@@ -74,11 +75,8 @@ class GetCable(object):
                         raise ("Error downloading repo")
                     f.close()
             else:
-                cmd = "svn checkout %s/trunk" % (
-                    self.root,
-                    self.user,
-                    repo_name,
-                )
+                cmd = f"svn checkout {rev_opt} {self.root}/trunk" 
+
                 error = subprocess.call(cmd, shell=True)
                 if error == 1:
                    raise ("Error downloading repo")
@@ -89,18 +87,9 @@ class GetCable(object):
             if need_pass:
 
                 if share_branch:
-                    cmd = "svn checkout %s/branches/Share/%s --password %s" % (
-                        self.root,
-                        repo_name,
-                        pswd,
-                    )
+                    cmd = f"svn checkout {rev_opt} {self.root}/branches/Share/{repo_name} --password {pswd}"
                 else:
-                    cmd = "svn checkout %s/branches/Users/%s/%s --password %s" % (
-                        self.root,
-                        self.user,
-                        repo_name,
-                        pswd,
-                    )
+                    cmd = f"svn checkout {rev_opt} {self.root}/branches/Users/{self.user}/{repo_name} --password {pswd}"
 
                 with tempfile.NamedTemporaryFile(mode="w+t") as f:
                     f.write(cmd)
@@ -112,13 +101,10 @@ class GetCable(object):
                     f.close()
             else:
                 if share_branch:
-                    cmd = "svn checkout %s/branches/Share/%s" % (self.root, repo_name)
+                    cmd = f"svn checkout {rev_opt} {self.root}/branches/Share/{repo_name}"
                 else:
-                    cmd = "svn checkout %s/branches/Users/%s/%s" % (
-                        self.root,
-                        self.user,
-                        repo_name,
-                    )
+                    cmd = f"svn checkout {rev_opt} {self.root}/branches/Users/{self.user}/{repo_name}"
+
                 error = subprocess.call(cmd, shell=True)
                 if error == 1:
                     raise ("Error downloading repo")

--- a/benchcab/get_cable.py
+++ b/benchcab/get_cable.py
@@ -59,48 +59,7 @@ class GetCable(object):
         if trunk:
 
             if need_pass:
-                # Check if we have a local copy of the trunk, if we do we won't
-                # write over this, otherwise we will check one out
-                cmd = "svn info %s/branches/Users/%s/%s --password %s" % (
-                    self.root,
-                    self.user,
-                    repo_name,
-                    pswd,
-                )
-
-                with tempfile.NamedTemporaryFile(mode="w+t") as f:
-                    f.write(cmd)
-                    f.flush()
-
-                    p = subprocess.Popen(
-                            cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
-                        )
-
-                    output, error = p.communicate()
-                    if error == 1:
-                        raise ("Error checking if repo exists")
-
-                    # error = subprocess.call(['/bin/bash', f.name])
-                    # if error == 1:
-                    #    raise("Error checking if repo exists")
-                    # f.close()
-
-                if "non-existent" in str(output) or "problem" in str(output):
-                    cmd = (
-                        "svn copy %s/trunk %s/branches/Users/%s/%s --password %s -m %s"
-                        % (self.root, self.root, self.user, repo_name, pswd, self.msg)
-                    )
-
-                    with tempfile.NamedTemporaryFile(mode="w+t") as f:
-                        f.write(cmd)
-                        f.flush()
-
-                        error = subprocess.call(["/bin/bash", f.name])
-                        if error == 1:
-                            raise ("Error checking out repo")
-                        f.close()
-
-                cmd = "svn checkout %s/branches/Users/%s/%s --password %s" % (
+                cmd = "svn checkout %s/trunk --password %s" % (
                     self.root,
                     self.user,
                     repo_name,
@@ -115,41 +74,14 @@ class GetCable(object):
                         raise ("Error downloading repo")
                     f.close()
             else:
-
-                # Check if we have a local copy of the trunk, if we do we won't
-                # write over this, otherwise we will check one out
-                cmd = "svn info %s/branches/Users/%s/%s" % (
-                    self.root,
-                    self.user,
-                    repo_name,
-                )
-                p = subprocess.Popen(
-                    cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
-                )
-                output, error = p.communicate()
-                if error == 1:
-                    raise ("Error checking if repo exists")
-
-                if "non-existent" in str(output) or "problem" in str(output):
-                    cmd = "svn copy %s/trunk %s/branches/Users/%s/%s -m %s" % (
-                        self.root,
-                        self.root,
-                        self.user,
-                        repo_name,
-                        self.msg,
-                    )
-                    error = subprocess.call(cmd, shell=True)
-                    if error == 1:
-                        raise ("Error checking out repo")
-
-                cmd = "svn checkout %s/branches/Users/%s/%s" % (
+                cmd = "svn checkout %s/trunk" % (
                     self.root,
                     self.user,
                     repo_name,
                 )
                 error = subprocess.call(cmd, shell=True)
                 if error == 1:
-                    raise ("Error downloading repo")
+                   raise ("Error downloading repo")
 
         # Checkout named branch ...
         else:

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.1.5" %}
+{% set version = "0.1.6" %}
 
 package:
   name: benchcab

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name=benchcab
 summary= Software to run a benchmarking suite for CABLE LSM
-version=0.1.5
+version=0.1.6
 description=To benchmark CABLE simulations
 url=https://github.com/CABLE-LSM/benchcab
 author=Claire Carouge

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,16 +13,19 @@ def testconfig():
         "use_branches":["user_branch","trunk"],
         "user_branch":{
             "name": "v3.0-YP-changes",
+            "revision": -1,
             "trunk": False,
             "share_branch": False,
             },
         "trunk":{
             "name": "trunk",
+            "revision": 9000,
             "trunk": True,
             "share_branch": False,
             },
         "share":{
             "name": "integration",
+            "revision": -1,
             "trunk": False,
             "share_branch": True,
             },

--- a/tests/test_workdir.py
+++ b/tests/test_workdir.py
@@ -72,4 +72,13 @@ def test_checkout_share(create_testconfig):
 
     checkout_branch("share", opt, tb)
 
+def test_checkout_2branches(create_testconfig):
+
+    td = create_testconfig[0]
+    os.chdir(td)
+    # Setup the benchmarking
+    opt, _, tb = create_testconfig[1:]
+
+    checkout_branch("share", opt, tb)
+    checkout_branch("user_branch", opt, tb)
 

--- a/tests/test_workdir.py
+++ b/tests/test_workdir.py
@@ -8,10 +8,10 @@ from benchcab import bench_config
 from benchcab import get_cable
 
 
-def checkout_branch(branch_type:str, opt:dict,tb:benchtree.BenchTree):
+def checkout_branch(branch_id:str, opt:dict,tb:benchtree.BenchTree):
 
-    # Check if the branch_type exists in file?
-    locbranch = opt[branch_type]
+    # Check if the branch_id exists in file?
+    locbranch = opt[branch_id]
     tr = get_cable.GetCable(src_dir=tb.src_dir, user=opt["user"])
     tr.main(**locbranch)
 
@@ -54,12 +54,22 @@ def test_checkout_trunk(create_testconfig):
 
     checkout_branch("trunk", opt, tb)
 
-# def test_checkout_user(create_testconfig, checkout_branch):
+def test_checkout_user(create_testconfig):
 
-#     checkout_branch("user_branch", create_testconfig)
+    td = create_testconfig[0]
+    os.chdir(td)
+    # Setup the benchmarking
+    opt, _, tb = create_testconfig[1:]
+
+    checkout_branch("user_branch", opt, tb)
  
-# def test_checkout_share(create_testconfig, checkout_branch):
+def test_checkout_share(create_testconfig):
 
-#     checkout_branch("share", create_testconfig)
+    td = create_testconfig[0]
+    os.chdir(td)
+    # Setup the benchmarking
+    opt, _, tb = create_testconfig[1:]
+
+    checkout_branch("share", opt, tb)
 
 


### PR DESCRIPTION
Now we checkout the trunk directly without a copy into a User branch. And there is a revision number added to the config.yaml file. This allows for the selection of a specific version of a branch to test instead of the HEAD.