### PR TITLE
Handling of revision number and a subset of met. sites

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,11 @@
 CHANGES
 =======
 
+* new version
+* Add specification of a subset of met. sites
+* Handling of revision number for branches
+* Formatting
+
 v0.1.5
 ------
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,10 @@
 CHANGES
 =======
 
+v0.1.5
+------
+
+* Update version
 * Log last change revision number for each branch
 * Add rev. number in svn checkout and config.yaml
 * Remove code to create user copy of trunk

--- a/benchcab/bench_config.py
+++ b/benchcab/bench_config.py
@@ -4,42 +4,58 @@ import os
 from benchcab.set_default_paths import set_paths
 from benchcab.benchtree import BenchTree
 
+
 class BenchSetup(object):
-    def __init__(self, myconfig:str):
+    def __init__(self, myconfig: str):
         """
         myconfig: str, Name of the config file to use for setup."""
 
         self.myconfig = myconfig
 
     @staticmethod
-    def check_config(opt:dict):
+    def check_config(opt: dict):
         """Run some checks on the config file to ensure the data is coherent.
         check1: make sure the names in use_branches are keys in the dictionary.
         check2: make sure all required entries are listed
         check3: add revision pointing to HEAD of branch if missing for one branch
+        check4: add met_subset entry if not in input file
         """
 
-        assert all([x in opt for x in opt["use_branches"][0:2]]), "At least one of the first 2 aliases " \
+        assert all([x in opt for x in opt["use_branches"][0:2]]), (
+            "At least one of the first 2 aliases "
             " listed in 'use_branches' is not an entry in the config file to define a CABLE branch."
+        )
 
-        assert all([x in opt for x in [
-            "use_branches",
-            "project",
-            "user",
-            "modules",
-            ]]), "The config file does not list all required entries. "\
-                "Those are 'use_branches', 'project', 'user', 'modules'"
-        
-        assert len(opt["use_branches"]) >= 2, "You need to list 2 branches in 'use_branches'"
+        assert all(
+            [
+                x in opt
+                for x in [
+                    "use_branches",
+                    "project",
+                    "user",
+                    "modules",
+                ]
+            ]
+        ), (
+            "The config file does not list all required entries. "
+            "Those are 'use_branches', 'project', 'user', 'modules'"
+        )
+
+        assert (
+            len(opt["use_branches"]) >= 2
+        ), "You need to list 2 branches in 'use_branches'"
         if len(opt["use_branches"]) > 2:
             print("------------------------------------------------------")
             print("Warning: more than 2 branches listed in 'use_branches'")
             print("Only the first 2 branches will be used.")
             print("------------------------------------------------------")
-            
-        # Add "revision" to each branch description if not provided with default value -1, i.e. HEAD of branch   
+
+        # Add "revision" to each branch description if not provided with default value -1, i.e. HEAD of branch
         for req_branch in opt["use_branches"][:2]:
-            opt[req_branch].setdefault("revision",-1)
+            opt[req_branch].setdefault("revision", -1)
+
+        # Add a "met_subset" key set to empty list if not found in config.yaml file.
+        opt.setdefault("met_subset", [])
 
     def read_config(self):
         """Read config file for the CABLE benchmarking"""
@@ -48,15 +64,15 @@ class BenchSetup(object):
 
         with open(Path(self.myconfig), "r") as fin:
             opt = yaml.safe_load(fin)
-        
+
         self.check_config(opt)
         return opt
 
     @staticmethod
-    def compilation_setup(ModToLoad:list):
-        """Load the modules and define the paths to libraries 
+    def compilation_setup(ModToLoad: list):
+        """Load the modules and define the paths to libraries
         depending on the machine name as needed for CABLE compilation.
-        
+
         ModToLoad: list, list of modules to load for Gadi. Empty list for other cases"""
 
         (_, nodename, _, _, _) = os.uname()
@@ -72,11 +88,8 @@ class BenchSetup(object):
         compilation_opt = self.compilation_setup(opt["modules"])
 
         # Setup the minimal benchmarking directory tree
-        myworkdir=Path.cwd()
-        benchdirs=BenchTree(myworkdir)
+        myworkdir = Path.cwd()
+        benchdirs = BenchTree(myworkdir)
         benchdirs.create_minbenchtree()
 
         return (opt, compilation_opt, benchdirs)
-
-
-

--- a/benchcab/bench_config.py
+++ b/benchcab/bench_config.py
@@ -16,6 +16,7 @@ class BenchSetup(object):
         """Run some checks on the config file to ensure the data is coherent.
         check1: make sure the names in use_branches are keys in the dictionary.
         check2: make sure all required entries are listed
+        check3: add revision pointing to HEAD of branch if missing for one branch
         """
 
         assert all([x in opt for x in opt["use_branches"][0:2]]), "At least one of the first 2 aliases " \
@@ -36,6 +37,9 @@ class BenchSetup(object):
             print("Only the first 2 branches will be used.")
             print("------------------------------------------------------")
             
+        # Add "revision" to each branch description if not provided with default value -1, i.e. HEAD of branch   
+        for req_branch in opt["use_branches"][:2]:
+            opt[req_branch].setdefault("revision",-1)
 
     def read_config(self):
         """Read config file for the CABLE benchmarking"""

--- a/benchcab/benchsiterun.py
+++ b/benchcab/benchsiterun.py
@@ -13,14 +13,30 @@ from benchcab.bench_config import BenchSetup
 # Define names of default config files globally
 default_config = "config.yaml"
 default_science = "site_configs.yaml"
+
+
 def myparse(arglist):
     """
     Parse arguments given as list (arglist)
     """
-    parser = argparse.ArgumentParser(description="Run CABLE simulations at single sites for benchmarking")
-    parser.add_argument("-q","--qsub", help="Creates a qsub job script if running at NCI", action="store_true")
-    parser.add_argument("-c","--config", help="Config filename", default=default_config)
-    parser.add_argument("-s", "--science_config", help="Config file to define the various configurations to run", default=default_science)
+    parser = argparse.ArgumentParser(
+        description="Run CABLE simulations at single sites for benchmarking"
+    )
+    parser.add_argument(
+        "-q",
+        "--qsub",
+        help="Creates a qsub job script if running at NCI",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-c", "--config", help="Config filename", default=default_config
+    )
+    parser.add_argument(
+        "-s",
+        "--science_config",
+        help="Config file to define the various configurations to run",
+        default=default_science,
+    )
 
     args = parser.parse_args(arglist)
 
@@ -31,26 +47,29 @@ def myparse(arglist):
         raise
 
     if not "nci" in nodename and not args.met_dir:
-        raise("You need to specify the path to the meteorological data if you are not running at NCI.")
+        raise (
+            "You need to specify the path to the meteorological data if you are not running at NCI."
+        )
 
     return args
+
 
 def read_sci_configs(sci_configfile):
     """Read the science config file"""
 
     with open(sci_configfile, "r") as fin:
-        sci_configs=yaml.safe_load(fin)
+        sci_configs = yaml.safe_load(fin)
 
     return sci_configs
 
 
-def main(qsub=False, config=default_config, science_config=default_science,**kwargs):
+def main(qsub=False, config=default_config, science_config=default_science, **kwargs):
     """To run CABLE on single sites for the benchmarking.
     Keyword arguments are the same as the command line arguments for the benchsiterun command
     """
     # Always run site simulations without mpi and with multiprocess
-    mpi=False
-    multiprocess=True
+    mpi = False
+    multiprocess = True
 
     # Read setup and create directory structure for single site runs
     mysetup = BenchSetup(config)
@@ -58,26 +77,28 @@ def main(qsub=False, config=default_config, science_config=default_science,**kwa
     benchdirs.create_sitebenchtree()
 
     # Read science configurations
-    sci_configs= read_sci_configs(science_config)
+    sci_configs = read_sci_configs(science_config)
 
     if qsub:
         # Create a script to launch on NCI's compute nodes if requested
         # Create a run object instance using default values since we won't use those values
-        R = RunCableSite( )
+        R = RunCableSite()
         R.create_qsub_script(opt["project"], opt["user"], config, science_config)
 
     else:
 
         # Aliases to branches to use:
         branch_alias = opt["use_branches"]
-        run_branches=[opt[branch_alias[0]],]
+        run_branches = [
+            opt[branch_alias[0]],
+        ]
         run_branches.append(opt[branch_alias[1]])
- 
-        start_dir=Path.cwd()
-        os.chdir(benchdirs.runroot_dir/"site")
+
+        start_dir = Path.cwd()
+        os.chdir(benchdirs.runroot_dir / "site")
         for branchid, branch in enumerate(run_branches):
             branch_name = branch["name"]
-            cable_src = benchdirs.src_dir/branch_name
+            cable_src = benchdirs.src_dir / branch_name
 
             # Define the name for the executable: cable for serial, cable-mpi for mpi runs
             cable_exe = f"cable{'-mpi'*mpi}"
@@ -110,11 +131,13 @@ def main_parse_args(arglist):
     # otherwise py.test will fail
     return main(**vars(myparse(arglist)))
 
+
 def main_argv():
     """
     Call main and pass command line arguments. This is required for setup.py entry_points
     """
     mess = main_parse_args(sys.argv[1:])
+
 
 if __name__ == "__main__":
 

--- a/benchcab/benchsiterun.py
+++ b/benchcab/benchsiterun.py
@@ -110,7 +110,7 @@ def main(qsub=False, config=default_config, science_config=default_science, **kw
                 restart_dir=benchdirs.site_run["restart_dir"],
                 aux_dir=benchdirs.aux_dir,
                 namelist_dir=benchdirs.site_run["namelist_dir"],
-                met_subset=[],
+                met_subset=opt["met_subset"],
                 cable_src=cable_src,
                 num_cores=None,
                 cable_exe=cable_exe,

--- a/benchcab/benchtree.py
+++ b/benchcab/benchtree.py
@@ -19,6 +19,40 @@ class BenchTree(object):
             "namelist_dir": self.runroot_dir/"site/namelists",
         }
 
+        self.clean_previous()
+
+    def clean_previous(self):
+        """Clean previous benchmarking runs as needed. 
+        Archives previous rev_number.log"""
+
+        revision_file=Path("rev_number.log")
+        if revision_file.exists():
+            revision_file.replace(self.next_path("rev_number-*.log"))
+
+        return
+
+    @staticmethod
+    def next_path(path_pattern, sep="-"):
+        """
+        Finds the next free path in a sequentially named list of files with the following pattern:
+            path_pattern = 'file{sep}*.suf':
+
+        file-1.txt
+        file-2.txt
+        file-3.txt
+        """
+
+        loc_pattern=Path(path_pattern)
+        new_file_index = 1
+        common_filename, _ = loc_pattern.stem.split(sep)
+
+        pattern_files_sorted = sorted(Path('.').glob(path_pattern))
+        if len(pattern_files_sorted):
+            common_filename, last_file_index = pattern_files_sorted[-1].stem.split(sep)
+            new_file_index = int(last_file_index) + 1
+
+        return f"{common_filename}{sep}{new_file_index}{loc_pattern.suffix}"
+
     def create_minbenchtree(self):
         """Create the minimum directory tree needed to run the CABLE benchmarking.
         At least, we need:

--- a/benchcab/run_cable_site.py
+++ b/benchcab/run_cable_site.py
@@ -59,6 +59,7 @@ class RunCableSite(object):
     ):
 
         self.met_dir = met_dir
+        self.met_subset = met_subset
         self.log_dir = log_dir
         self.output_dir = output_dir
         self.restart_dir = restart_dir
@@ -75,7 +76,6 @@ class RunCableSite(object):
         self.cnpbiome_fname = os.path.join(self.biogeochem_dir, cnpbiome_fname)
         self.elev_fname = elev_fname
         self.co2_conc = co2_conc
-        self.met_subset = met_subset
         self.cable_src = cable_src
         self.cable_exe = os.path.join(cable_src, "offline/%s" % (cable_exe))
         self.veg_nml = Path(cable_src, f"offline/{veg_nml}")

--- a/benchcab/run_cable_site.py
+++ b/benchcab/run_cable_site.py
@@ -56,7 +56,7 @@ class RunCableSite(object):
         num_cores=None,
         multiprocess=False,
         verbose=False,
-    ):        
+    ):
 
         self.met_dir = met_dir
         self.log_dir = log_dir
@@ -178,7 +178,7 @@ class RunCableSite(object):
             adjust_nml_file(nml_fname, replace_dict)
 
             self.run_me(nml_fname)
-            
+
             add_attributes_to_output_file(nml_fname, out_fname, sci_config, url, rev)
             shutil.move(nml_fname, os.path.join(self.namelist_dir, nml_fname))
 
@@ -198,10 +198,10 @@ class RunCableSite(object):
         # - cable executable
         # - veg. parameters namelist
         # - soil parameters namelist
-        copies={
-            self.cable_exe:"cable",
-            self.veg_nml:Path(self.veg_nml).name,
-            self.soil_nml:Path(self.soil_nml).name,
+        copies = {
+            self.cable_exe: "cable",
+            self.veg_nml: Path(self.veg_nml).name,
+            self.soil_nml: Path(self.soil_nml).name,
         }
         self.copy_files(copies)
         self.cable_exe = copies[self.cable_exe]
@@ -270,12 +270,12 @@ class RunCableSite(object):
         email_address = f"{user}@nci.org.au"
 
         # Add the local directory to the storage flag for PBS
-        curdir=Path.cwd().parts
-        if ("scratch" in curdir):
-            curdir_root="scratch"
+        curdir = Path.cwd().parts
+        if "scratch" in curdir:
+            curdir_root = "scratch"
             curdir_proj = curdir[2]
-        elif ("g" in curdir and "data" in curdir):
-            curdir_root="gdata"
+        elif "g" in curdir and "data" in curdir:
+            curdir_root = "gdata"
             curdir_proj = curdir[3]
         else:
             print("Current directory structure unknown on Gadi")
@@ -293,7 +293,9 @@ class RunCableSite(object):
         f.write("#PBS -P %s\n" % (project))
         f.write("#PBS -j oe\n")
         f.write("#PBS -M %s\n" % (email_address))
-        f.write(f"#PBS -l storage=gdata/ks32+gdata/wd9+gdata/hh5+gdata/{project}+{curdir_root}/{curdir_proj}\n")
+        f.write(
+            f"#PBS -l storage=gdata/ks32+gdata/wd9+gdata/hh5+gdata/{project}+{curdir_root}/{curdir_proj}\n"
+        )
         f.write("\n")
         f.write("\n")
         f.write("\n")
@@ -307,7 +309,7 @@ class RunCableSite(object):
 
         f.close()
 
-        os.chmod(qsub_fname, 0o755)        
+        os.chmod(qsub_fname, 0o755)
 
 
 def merge_two_dicts(x, y):

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.1.6" %}
+{% set version = "0.1.7" %}
 
 package:
   name: benchcab

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name=benchcab
 summary= Software to run a benchmarking suite for CABLE LSM
-version=0.1.6
+version=0.1.7
 description=To benchmark CABLE simulations
 url=https://github.com/CABLE-LSM/benchcab
 author=Claire Carouge


### PR DESCRIPTION
This adds 2 things:

- better handling of the revision number per branch. We want to be able to run for a specified revision number or from the HEAD of each branch independently. Now each run of benchcab writes out the revision numbers used in a different file.
- run for a subset of the PLUMBER2 sites. It's now possible to specify sites to run in the config.yaml file under a `met_subset` list. For the moment, one needs to specify the exact filenames, it will need to be changed to specifying the site name instead and the code figuring out the filename for each site.