### PR TITLE
Add me.org met site configurations

### DIFF
--- a/benchcab/bench_config.py
+++ b/benchcab/bench_config.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import re
 import yaml
 
+from benchcab.internal import MEORG_PLUMBER_MET_FILES
+
 
 def check_config(config: dict):
     """Performs input validation on config file.
@@ -32,6 +34,17 @@ def check_config(config: dict):
 
     if not isinstance(config["modules"], list):
         raise TypeError("The 'modules' key must be a list.")
+
+    # the "met_subset" key is optional
+    if "met_subset" in config:
+        if not isinstance(config["met_subset"], list):
+            raise TypeError("The 'met_subset' key must be a list.")
+        if not set(config["met_subset"]).issubset(MEORG_PLUMBER_MET_FILES):
+            raise ValueError(
+                "The files listed in 'met_subset' must be a subset of of the 20 "
+                "PLUMBER sites associated with CABLE_multisite_PLUMBER experiment "
+                "on modelevaluation.org."
+            )
 
     if len(config["realisations"]) != 2:
         raise ValueError("You need to list 2 branches in 'realisations'")
@@ -109,8 +122,12 @@ def read_config(config_path: str) -> dict:
     for branch in config['realisations'].values():
         branch.setdefault('revision', -1)
 
-    # Add a "met_subset" key set to empty list if not found in config.yaml file.
-    config.setdefault("met_subset", [])
+    # Add a "met_subset" key set to MEORG_PLUMBER_MET_FILES if not found in config.yaml file.
+    config.setdefault("met_subset", MEORG_PLUMBER_MET_FILES)
+
+    # Set "met_subset" to MEORG_PLUMBER_MET_FILES if empty:
+    if config["met_subset"] == []:
+        config["met_subset"] = MEORG_PLUMBER_MET_FILES
 
     return config
 

--- a/benchcab/benchcab.py
+++ b/benchcab/benchcab.py
@@ -10,7 +10,7 @@ from benchcab.bench_config import read_config, read_science_config
 from benchcab.benchtree import setup_fluxnet_directory_tree, setup_src_dir
 from benchcab.build_cable import build_cable_offline
 from benchcab.get_cable import checkout_cable, checkout_cable_auxiliary, archive_rev_number
-from benchcab.internal import validate_environment
+from benchcab.internal import validate_environment, get_met_sites
 from benchcab.task import get_fluxnet_tasks
 
 
@@ -89,7 +89,11 @@ def main(args):
     if args.fluxnet:
         print("Running the single sites tests ")
 
-        tasks = get_fluxnet_tasks(config, sci_configs)
+        tasks = get_fluxnet_tasks(
+            config=config,
+            science_config=sci_configs,
+            met_sites=get_met_sites(config['experiment'])
+        )
 
         setup_fluxnet_directory_tree(fluxnet_tasks=tasks)
 

--- a/benchcab/benchsiterun.py
+++ b/benchcab/benchsiterun.py
@@ -13,7 +13,8 @@ import numpy as np
 
 from benchcab.run_cable_site import run_tasks
 from benchcab import internal
-from benchcab.internal import validate_environment, DEFAULT_CONFIG, DEFAULT_SCIENCE
+from benchcab.internal import validate_environment, get_met_sites
+from benchcab.internal import DEFAULT_CONFIG, DEFAULT_SCIENCE
 from benchcab.task import get_fluxnet_tasks
 from benchcab.bench_config import read_config, read_science_config
 
@@ -60,7 +61,11 @@ def main(args):
 
     validate_environment(project=config['project'], modules=config['modules'])
 
-    tasks = get_fluxnet_tasks(config, sci_configs)
+    tasks = get_fluxnet_tasks(
+        config=config,
+        science_config=sci_configs,
+        met_sites=get_met_sites(config['experiment'])
+    )
 
     if internal.MULTIPROCESS:
         num_cores = cpu_count() if internal.NUM_CORES is None else internal.NUM_CORES

--- a/benchcab/internal.py
+++ b/benchcab/internal.py
@@ -82,6 +82,32 @@ CABLE_SOIL_NML = "cable_soilparm.nml"
 # CABLE fixed C02 concentration
 CABLE_FIXED_CO2_CONC = 400.0
 
+# List of the 20 met forcing files associated with the CABLE_multisite_PLUMBER
+# experiment on modelevaluation.org, see:
+# https://modelevaluation.org/experiment/display/XMdi5K4zJpTe2S8aM
+MEORG_PLUMBER_MET_FILES = [
+    "AU-How_2003-2017_OzFlux_Met.nc",       # AU-How - PLUMBER
+    "AU-Tum_2002-2017_OzFlux_Met.nc",       # AU-Tum - PLUMBER
+    "BW-Ma1_2000-2000_LaThuile_Met.nc",     # BW-Ma1 - PLUMBER
+    # "CA-Mer - PLUMBER",                   # CA-Mer - PLUMBER
+    "ES-ES1_1999-2006_LaThuile_Met.nc",     # ES-ES1 - PLUMBER
+    "ES-ES2_2005-2006_LaThuile_Met.nc",     # ES-ES2 - PLUMBER
+    "FI-Hyy_1996-2014_FLUXNET2015_Met.nc",  # FI-Hyy - PLUMBER
+    "FR-Hes_1997-2006_LaThuile_Met.nc",     # FR-Hes - PLUMBER
+    "HU-Bug_2003-2006_LaThuile_Met.nc",     # HU-Bug - PLUMBER
+    "ID-Pag_2002-2003_LaThuile_Met.nc",     # ID-Pag - PLUMBER
+    "IT-Amp_2003-2006_LaThuile_Met.nc",     # IT-Amp - PLUMBER
+    "NL-Loo_1997-2013_FLUXNET2015_Met.nc",  # NL-Loo - PLUMBER
+    "PT-Esp_2002-2004_LaThuile_Met.nc",     # PT-Esp - PLUMBER
+    "US-Blo_2000-2006_FLUXNET2015_Met.nc",  # US-Blo - PLUMBER
+    "US-FPe_2000-2006_LaThuile_Met.nc",     # US-FPe - PLUMBER
+    "US-Ha1_1992-2012_FLUXNET2015_Met.nc",  # US-Ha1 - PLUMBER
+    "US-Ho1_1996-2004_LaThuile_Met.nc",     # US-Ho1 - PLUMBER
+    "US-Syv_2002-2008_FLUXNET2015_Met.nc",  # US-Syv - PLUMBER
+    "US-UMB_2000-2014_FLUXNET2015_Met.nc",  # US-UMB - PLUMBER
+    "ZA-Kru_2000-2002_FLUXNET2015_Met.nc",  # ZA-Kru - PLUMBER
+]
+
 
 def validate_environment(project: str, modules: list):
     '''Performs checks on current user environment'''
@@ -109,4 +135,10 @@ def validate_environment(project: str, modules: list):
     for modname in modules:
         if not module("is-avail", modname):
             print(f"Error: module ({modname}) is not available.")
+            sys.exit(1)
+
+    for met_file_name in MEORG_PLUMBER_MET_FILES:
+        met_file_path = Path(MET_DIR, met_file_name)
+        if not met_file_path.exists():
+            print(f"Error: cannot find met file {met_file_path}")
             sys.exit(1)

--- a/benchcab/internal.py
+++ b/benchcab/internal.py
@@ -4,7 +4,6 @@ import os
 import sys
 import grp
 from pathlib import Path
-import re
 
 _, NODENAME, _, _, _ = os.uname()
 

--- a/benchcab/internal.py
+++ b/benchcab/internal.py
@@ -156,11 +156,12 @@ def get_met_sites(experiment: str) -> list[str]:
 
     if experiment in MEORG_EXPERIMENTS["five-site-test"]:
         # the user is specifying a single met site
-        return list(map(lambda path: path.name, MET_DIR.glob(f"{experiment}*")))
+        return [next(MET_DIR.glob(f"{experiment}*")).name]
 
-    met_sites = []
-    for site_id in MEORG_EXPERIMENTS[experiment]:
-        met_sites += list(map(lambda path: path.name, MET_DIR.glob(f"{site_id}*")))
+    met_sites = [
+        next(MET_DIR.glob(f"{site_id}*")).name
+        for site_id in MEORG_EXPERIMENTS[experiment]
+    ]
 
     return met_sites
 

--- a/benchcab/task.py
+++ b/benchcab/task.py
@@ -138,7 +138,7 @@ class Task:
             .adjust_namelist_file()
 
 
-def get_fluxnet_tasks(config: dict, science_config: dict) -> list[Task]:
+def get_fluxnet_tasks(config: dict, science_config: dict, met_sites: list[str]) -> list[Task]:
     """Returns a list of fluxnet tasks to run."""
     # TODO(Sean) convert this to a generator
     tasks = [
@@ -150,7 +150,7 @@ def get_fluxnet_tasks(config: dict, science_config: dict) -> list[Task]:
             sci_config=science_config[key]
         )
         for id, branch in config["realisations"].items()
-        for site in config["met_subset"]
+        for site in met_sites
         for key in science_config
     ]
     return tasks

--- a/benchcab/task.py
+++ b/benchcab/task.py
@@ -3,7 +3,6 @@
 import os
 import shutil
 from pathlib import Path
-import glob
 import f90nml
 
 from benchcab import internal

--- a/benchcab/task.py
+++ b/benchcab/task.py
@@ -142,7 +142,6 @@ class Task:
 def get_fluxnet_tasks(config: dict, science_config: dict) -> list[Task]:
     """Returns a list of fluxnet tasks to run."""
     # TODO(Sean) convert this to a generator
-    met_sites = get_all_met_sites() if config["met_subset"] == [] else config["met_subset"]
     tasks = [
         Task(
             branch_id=id,
@@ -151,11 +150,8 @@ def get_fluxnet_tasks(config: dict, science_config: dict) -> list[Task]:
             sci_conf_key=key,
             sci_config=science_config[key]
         )
-        for id, branch in config["realisations"].items() for site in met_sites for key in science_config
+        for id, branch in config["realisations"].items()
+        for site in config["met_subset"]
+        for key in science_config
     ]
     return tasks
-
-
-def get_all_met_sites():
-    """Get list of all met files in `MET_DIR` directory."""
-    return list(map(os.path.basename, glob.glob(os.path.join(internal.MET_DIR, "*.nc"))))

--- a/tests/common.py
+++ b/tests/common.py
@@ -10,7 +10,7 @@ def make_barebones_config() -> dict:
     conf = {
         "user": "foo1234",
         "project": "bar",
-        "met_subset": ["AU-How_2003-2017_OzFlux_Met.nc"],
+        "experiment": "five-site-test",
         "modules": [
             "intel-compiler/2021.1.1",
             "openmpi/4.1.0",

--- a/tests/common.py
+++ b/tests/common.py
@@ -10,7 +10,7 @@ def make_barebones_config() -> dict:
     conf = {
         "user": "foo1234",
         "project": "bar",
-        "met_subset": [],
+        "met_subset": ["AU-How_2003-2017_OzFlux_Met.nc"],
         "modules": [
             "intel-compiler/2021.1.1",
             "openmpi/4.1.0",

--- a/tests/test_bench_config.py
+++ b/tests/test_bench_config.py
@@ -152,7 +152,7 @@ def test_read_config():
     res = read_config(filename)
     os.remove(filename)
     assert config != res
-    assert "revision" in res["realisations"][0] and res["realisations"][0]["revision"] == -1
+    assert res["realisations"][0]["revision"] == -1
 
     # Success case: config branch with missing key: met_subset
     # should return a config with met_subset = empty list
@@ -166,7 +166,7 @@ def test_read_config():
     res = read_config(filename)
     os.remove(filename)
     assert config != res
-    assert "met_subset" in res and res["met_subset"] == []
+    assert res["met_subset"] == []
 
 
 def test_check_science_config():


### PR DESCRIPTION
These changes allow users to run a set of standard tests (experiments) for CABLE from which model output can be piped into [modelevaluation.org](modelevaluation.org). In particular we
- no longer default to running CABLE with all met files in the FLUXNET dataset.
- now use preset experiments that enforce which met sites are to be used. These are defined in the NRI Land testing workspace on [modelevaluation.org](modelevaluation.org).

This addresses issues #10 and #25.