### PR TITLE
Use `TMPDIR` environment variable instead of CWD

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -1,8 +1,9 @@
 """Helper functions for `pytest`."""
 
+import os
 from pathlib import Path
 
-TMP_DIR = Path.cwd() / "tests" / "tmp"
+TMP_DIR = Path(os.environ["TMPDIR"], "benchcab_tests")
 
 
 def make_barebones_config() -> dict:

--- a/tests/test_benchtree.py
+++ b/tests/test_benchtree.py
@@ -19,12 +19,7 @@ def run_around_tests():
     # Setup:
     if TMP_DIR.exists():
         shutil.rmtree(TMP_DIR)
-    try:
-        TMP_DIR.mkdir()
-    except FileNotFoundError as err:
-        print(err, "\n")
-        print("Try running pytest from the project root directory.")
-        raise
+    TMP_DIR.mkdir()
 
     # Run the test:
     yield

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -19,12 +19,7 @@ def run_around_tests():
     # Setup:
     if TMP_DIR.exists():
         shutil.rmtree(TMP_DIR)
-    try:
-        TMP_DIR.mkdir()
-    except FileNotFoundError as err:
-        print(err, "\n")
-        print("Try running pytest from the project root directory.")
-        raise
+    TMP_DIR.mkdir()
 
     # Run the test:
     yield


### PR DESCRIPTION
Previously, `pytest` fails if the command is not run from the project root directory. This change uses the `TMPDIR` environment variable instead of `Path.cwd()` so that `pytest` runs correctly from any directory.

Using `TMPDIR` has the added benefit that we won't run into permission issues if we run the tests on a central installation of `benchcab`.

Fixes #26