### PR TITLE
Add support for patching derived types

### DIFF
--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -156,7 +156,9 @@ def test_adjust_namelist_file():
         'cable': {
             'filename': {
                 'met': "/path/to/met/file",
+                'foo': 123
             },
+            'bar': 123
         }
     }
 
@@ -184,3 +186,6 @@ def test_adjust_namelist_file():
     assert res_nml['cable']['casafile']['cnpbiome'] == str(cnpbiome_file_path)
     assert res_nml['cable']['spinup'] is False
     assert res_nml['cable']['some_setting'] is True
+
+    assert res_nml['cable']['filename']['foo'] == 123, "assert existing derived types are preserved"
+    assert res_nml['cable']['bar'] == 123, "assert existing top-level parameters are preserved"


### PR DESCRIPTION
Currently the `patch` method in the [f90nml](https://github.com/marshallward/f90nml) package does not preserve existing derived type parameters when a derived type patch is applied.

This change allows for existing derived type parameters to be preserved when adjusting the namelist file for each task.

Update unit tests for `adjust_namelist_file()` to test existing namelist parameters are preserved.