### PR TITLE
Specify namelist name in science configurations

### DIFF
--- a/benchcab/internal.py
+++ b/benchcab/internal.py
@@ -84,32 +84,40 @@ CABLE_FIXED_CO2_CONC = 400.0
 # Contains the default science configurations used to run the CABLE test suite
 # (when a science config file is not provided by the user)
 DEFAULT_SCIENCE_CONFIGURATIONS = {
-    "sci0": {"cable_user": {"GS_SWITCH": "medlyn"}},
-    "sci1": {"cable_user": {"GS_SWITCH": "leuning"}},
-    "sci2": {"cable_user": {"FWSOIL_SWITCH": "Haverd2013"}},
-    "sci3": {"cable_user": {"FWSOIL_SWITCH": "standard"}},
+    "sci0": {"cable": {"cable_user": {"GS_SWITCH": "medlyn"}}},
+    "sci1": {"cable": {"cable_user": {"GS_SWITCH": "leuning"}}},
+    "sci2": {"cable": {"cable_user": {"FWSOIL_SWITCH": "Haverd2013"}}},
+    "sci3": {"cable": {"cable_user": {"FWSOIL_SWITCH": "standard"}}},
     "sci4": {
-        "cable_user": {
-            "GS_SWITCH": "medlyn",
-            "FWSOIL_SWITCH": "Haverd2013",
+        "cable": {
+            "cable_user": {
+                "GS_SWITCH": "medlyn",
+                "FWSOIL_SWITCH": "Haverd2013",
+            }
         }
     },
     "sci5": {
-        "cable_user": {
-            "GS_SWITCH": "leuning",
-            "FWSOIL_SWITCH": "Haverd2013",
+        "cable": {
+            "cable_user": {
+                "GS_SWITCH": "leuning",
+                "FWSOIL_SWITCH": "Haverd2013",
+            }
         }
     },
     "sci6": {
-        "cable_user": {
-            "GS_SWITCH": "medlyn",
-            "FWSOIL_SWITCH": "standard",
+        "cable": {
+            "cable_user": {
+                "GS_SWITCH": "medlyn",
+                "FWSOIL_SWITCH": "standard",
+            }
         }
     },
     "sci7": {
-        "cable_user": {
-            "GS_SWITCH": "leuning",
-            "FWSOIL_SWITCH": "standard",
+        "cable": {
+            "cable_user": {
+                "GS_SWITCH": "leuning",
+                "FWSOIL_SWITCH": "standard",
+            }
         }
     },
 }

--- a/benchcab/task.py
+++ b/benchcab/task.py
@@ -133,7 +133,7 @@ class Task:
             }
         }
 
-        patch_nml["cable"].update(self.sci_config)
+        patch_nml = deep_update(patch_nml, self.sci_config)
 
         self.patch_namelist_file(patch_nml, root_dir=root_dir)
 

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -42,7 +42,7 @@ def setup_mock_task() -> Task:
         branch_patch={"cable": {"some_branch_specific_setting": True}},
         met_forcing_file="forcing-file.nc",
         sci_conf_key="sci0",
-        sci_config={"some_setting": True}
+        sci_config={"cable": {"some_setting": True}}
     )
     return task
 


### PR DESCRIPTION
Specify `cable` in the top level of each science config dictionary. This is consistent with how branch specific namelist patches are specified in the config file.

Fixes #46