### PR TITLE
fix #45: Github actions to publish on Pages

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -26,7 +26,6 @@ runs:
       shell: bash
 
     - name: Build documentation
-      working-directory: documentation
       run: |
         # outputs to "site" directory
         mkdocs build -f mkdocs.yml

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -22,7 +22,7 @@ runs:
 
     - name: Install dependencies for mkdocs
       run: | 
-        pip install -r documentation/mkdocs-requirements.txt
+        pip install -r mkdocs-requirements.txt
       shell: bash
 
     - name: Build documentation

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -1,0 +1,33 @@
+name: Build docs
+description: Build mkdocs
+inputs:
+  name:
+    required: false
+    description: "Name"
+
+outputs:
+  random:
+    description: "Random number output"
+    value: ${{ steps.step1.outputs.random }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.x
+
+    - name: Install dependencies for mkdocs
+      run: | 
+        pip install -r documentation/mkdocs-requirements.txt
+      shell: bash
+
+    - name: Build documentation
+      working-directory: documentation
+      run: |
+        # outputs to "site" directory
+        mkdocs build -f mkdocs.yml
+      shell: bash

--- a/.github/workflows/build_and_preview.yml
+++ b/.github/workflows/build_and_preview.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Deploy preview
         uses: rossjrw/pr-preview-action@v1.2
         with:
-          source-dir: documentation/site
+          source-dir: site

--- a/.github/workflows/build_and_preview.yml
+++ b/.github/workflows/build_and_preview.yml
@@ -1,0 +1,28 @@
+name: Build and deploy PR preview
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+concurrency: 
+  group: preview-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_and_deploy_preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout # Necessary to access local action
+        uses: actions/checkout@v3
+
+      - name: Build docs
+        uses: ./.github/actions/build
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1.2
+        with:
+          source-dir: documentation/site

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -21,5 +21,5 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           branch: gh-pages # default
-          folder: documentation/site
+          folder: site
           clean-exclude: pr-preview/ # don't overwrite previews

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -1,0 +1,25 @@
+name: Build and publish docs
+
+on:
+  push:
+    branches: 
+      - master
+
+jobs:
+  build_and_deploy_docs:
+    concurrency: ci-${{ github.ref }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout # Necessary to access local action
+        uses: actions/checkout@v3
+
+      - name: Build docs
+        uses: ./.github/actions/build
+
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages # default
+          folder: documentation/site
+          clean-exclude: pr-preview/ # don't overwrite previews

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ __pycache__/*
 .DS_Store
 *.pyc
 benchcab.egg-info
-build/
+/build/

--- a/mkdocs-requirements.txt
+++ b/mkdocs-requirements.txt
@@ -1,0 +1,4 @@
+mkdocs>1.1
+mkdocs-material>=7.2.6
+mkdocs-git-revision-date-localized-plugin
+mkdocs-macros-plugin


### PR DESCRIPTION
Fix #45 . 

The publishing workflow from master branch has worked on my own personal branch:
- published site: https://ccarouge.github.io/benchcab/
- actions summary: https://github.com/ccarouge/benchcab/actions 

The publishing workflow for a preview has worked in this PR.