### PR TITLE
Use TMP_DIR when reading and writing files

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+"""Contains pytest fixtures accessible to all tests in the same directory."""
+
+import shutil
+import pytest
+
+from .common import TMP_DIR
+
+
+@pytest.fixture(autouse=True)
+def run_around_tests():
+    """`pytest` autouse fixture that runs around each test."""
+
+    # Setup:
+    if TMP_DIR.exists():
+        shutil.rmtree(TMP_DIR)
+    TMP_DIR.mkdir()
+
+    # Run the test:
+    yield
+
+    # Teardown:
+    shutil.rmtree(TMP_DIR)

--- a/tests/test_bench_config.py
+++ b/tests/test_bench_config.py
@@ -4,6 +4,7 @@ import os
 import pytest
 import yaml
 
+from tests.common import TMP_DIR
 from tests.common import make_barebones_config
 from benchcab.bench_config import check_config, read_config, get_science_config_id
 from benchcab.internal import DEFAULT_SCIENCE_CONFIGURATIONS
@@ -220,7 +221,7 @@ def test_read_config():
 
     # Success case: write config to file, then read config from file
     config = make_barebones_config()
-    filename = "config-barebones.yaml"
+    filename = TMP_DIR / "config-barebones.yaml"
 
     with open(filename, "w", encoding="utf-8") as file:
         yaml.dump(config, file)
@@ -233,7 +234,7 @@ def test_read_config():
     # should return a config with the default revision number
     config = make_barebones_config()
     config["realisations"][0].pop("revision")
-    filename = "config-barebones.yaml"
+    filename = TMP_DIR / "config-barebones.yaml"
 
     with open(filename, "w", encoding="utf-8") as file:
         yaml.dump(config, file)
@@ -243,12 +244,11 @@ def test_read_config():
     assert config != res
     assert res["realisations"][0]["revision"] == -1
 
-
     # Success case: a specified branch with a missing patch dictionary
     # should return a config with patch set to its default value
     config = make_barebones_config()
     config["realisations"][0].pop("patch")
-    filename = "config-barebones.yaml"
+    filename = TMP_DIR / "config-barebones.yaml"
 
     with open(filename, "w", encoding="utf-8") as file:
         yaml.dump(config, file)
@@ -258,13 +258,12 @@ def test_read_config():
     assert config != res
     assert res["realisations"][0]["patch"] == {}
 
-
     # Success case: a config with missing science_configurations key should return a
     # config with config['science_configurations'] set to its default value
     config = make_barebones_config()
     config.pop("science_configurations")
-    filename = "config-barebones.yaml"
-    
+    filename = TMP_DIR / "config-barebones.yaml"
+
     with open(filename, "w", encoding="utf-8") as file:
         yaml.dump(config, file)
 

--- a/tests/test_benchtree.py
+++ b/tests/test_benchtree.py
@@ -1,8 +1,6 @@
 """`pytest` tests for benchtree.py"""
 
-import shutil
 from pathlib import Path
-import pytest
 
 
 from tests.common import TMP_DIR
@@ -10,22 +8,6 @@ from tests.common import make_barebones_config
 from benchcab.task import Task
 from benchcab.benchtree import setup_fluxnet_directory_tree, clean_directory_tree, setup_src_dir
 from benchcab.bench_config import get_science_config_id
-
-
-@pytest.fixture(autouse=True)
-def run_around_tests():
-    """`pytest` autouse fixture that runs around each test."""
-
-    # Setup:
-    if TMP_DIR.exists():
-        shutil.rmtree(TMP_DIR)
-    TMP_DIR.mkdir()
-
-    # Run the test:
-    yield
-
-    # Teardown:
-    shutil.rmtree(TMP_DIR)
 
 
 def test_setup_directory_tree():

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -1,31 +1,13 @@
 """`pytest` tests for task.py"""
 
 import os
-import shutil
 from pathlib import Path
 import f90nml
-import pytest
 
 from tests.common import TMP_DIR
 from benchcab.task import Task
 from benchcab import internal
 from benchcab.benchtree import setup_fluxnet_directory_tree
-
-
-@pytest.fixture(autouse=True)
-def run_around_tests():
-    """`pytest` autouse fixture that runs around each test."""
-
-    # Setup:
-    if TMP_DIR.exists():
-        shutil.rmtree(TMP_DIR)
-    TMP_DIR.mkdir()
-
-    # Run the test:
-    yield
-
-    # Teardown:
-    shutil.rmtree(TMP_DIR)
 
 
 def touch(path):


### PR DESCRIPTION
We should always use `TMP_DIR` so that when tests fail, all files are cleaned up.

This change allows all tests to use the same setup/teardown pytest fixture.

Fixes https://github.com/CABLE-LSM/benchcab/issues/41