### PR TITLE
Polish `subprocess` calls

### DIFF
--- a/benchcab/job_script.py
+++ b/benchcab/job_script.py
@@ -2,7 +2,6 @@
 
 import os
 import sys
-import shlex
 import subprocess
 from pathlib import Path
 
@@ -62,8 +61,8 @@ def create_job_script(
 def submit_job():
     """Submits the job script specified by `QSUB_FNAME`."""
 
-    cmd = shlex.split(f"qsub {QSUB_FNAME}")
-    proc = subprocess.run(cmd, capture_output=True, check=False)
+    cmd = f"qsub {QSUB_FNAME}"
+    proc = subprocess.run(cmd, shell=True, capture_output=True, text=True, check=False)
     if proc.returncode != 0:
         print("Error when submitting job to NCI queue")
         print(proc.stderr)


### PR DESCRIPTION
- Add `text=True` to subprocess.run() arguments so that captured output is formatted as a string.
- Replace the `shlex` module by adding the `shell=True` argument.
- Replace `subprocess.call` with `subprocess.run` as this is recommended for most use cases. Use the built in `subprocess.CalledProcessError` exception type for error handling.

Note, code related to building CABLE is left untouched (this will likely be refactored in a later PR).

Fixes #39