### PR TITLE
Replace `config` argument with `realisations`

### DIFF
--- a/benchcab/benchcab.py
+++ b/benchcab/benchcab.py
@@ -83,7 +83,7 @@ def main(args):
         print("Running the single sites tests ")
 
         tasks = get_fluxnet_tasks(
-            config=config,
+            realisations=config["realisations"],
             science_config=config['science_configurations'],
             met_sites=get_met_sites(config['experiment'])
         )

--- a/benchcab/benchsiterun.py
+++ b/benchcab/benchsiterun.py
@@ -55,7 +55,7 @@ def main(args):
     validate_environment(project=config['project'], modules=config['modules'])
 
     tasks = get_fluxnet_tasks(
-        config=config,
+        realisations=config["realisations"],
         science_config=config['science_configurations'],
         met_sites=get_met_sites(config['experiment'])
     )

--- a/benchcab/task.py
+++ b/benchcab/task.py
@@ -175,7 +175,7 @@ class Task:
             self.patch_namelist_file(self.branch_patch, root_dir=root_dir)
 
 
-def get_fluxnet_tasks(config: dict, science_config: dict, met_sites: list[str]) -> list[Task]:
+def get_fluxnet_tasks(realisations: dict, science_config: dict, met_sites: list[str]) -> list[Task]:
     """Returns a list of fluxnet tasks to run."""
     # TODO(Sean) convert this to a generator
     tasks = [
@@ -187,7 +187,7 @@ def get_fluxnet_tasks(config: dict, science_config: dict, met_sites: list[str]) 
             sci_conf_key=key,
             sci_config=science_config[key]
         )
-        for id, branch in config["realisations"].items()
+        for id, branch in realisations.items()
         for site in met_sites
         for key in science_config
     ]


### PR DESCRIPTION
We should avoid passing in the whole config dictionary as arguments to `get_fluxnet_tasks()`.

Fixes #31