### PR TITLE
Add version flag

### DIFF
--- a/benchcab/__init__.py
+++ b/benchcab/__init__.py
@@ -1,1 +1,3 @@
-import benchcab.benchcab as benchcab
+import importlib.metadata
+
+__version__ = importlib.metadata.version('benchcab')

--- a/benchcab/benchcab.py
+++ b/benchcab/benchcab.py
@@ -5,6 +5,7 @@
 import argparse
 import sys
 
+import benchcab
 from benchcab.job_script import create_job_script, submit_job
 from benchcab.bench_config import read_config
 from benchcab.benchtree import setup_fluxnet_directory_tree, setup_src_dir
@@ -48,6 +49,12 @@ def parse_args(arglist):
         action="store_true",
         default=False,
         help="Rebuild src?"
+    )
+    parser.add_argument(
+        "-V",
+        "--version",
+        action="version",
+        version=f"benchcab {benchcab.__version__}"
     )
 
     args = parser.parse_args(arglist)

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,4 +1,5 @@
-{% set version = "1.0" %}
+{% set data = load_setup_py_data() %}
+{% set version = data.get('version')  %}
 
 package:
   name: benchcab


### PR DESCRIPTION
Currently the version is hard coded in both `setup.cfg` and `meta.yaml`. Ideally, we want the version number to be defined in a single place in the code base. This change defines the `setup.cfg` file to be the single source of truth for the version number.

Use `importlib` to obtain the version number from `setup.cfg` and store in the `__version__` dunder variable in `benchcab/__init__.py`.

Add a `--version` command line flag to `benchcab` which prints the version number to stdout.

Use Jinja2 templating with `load_setup_py_data()` to render the version number in `meta.yaml`. See [conda docs] for details.

The following commands have been tested:
- `pip install --user .` success.
- `conda build -c conda-forge .` success.
- `benchcab -f` success.

Fixes https://github.com/CABLE-LSM/benchcab/issues/38

[conda docs]: https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#templating-with-jinja