### PR TITLE
Add ability to use branches of other users

### DIFF
--- a/benchcab/bench_config.py
+++ b/benchcab/bench_config.py
@@ -63,20 +63,18 @@ def check_config(config: dict):
     for branch_id, branch_config in enumerate(config["realisations"]):
         if not isinstance(branch_config, dict):
             raise TypeError(f"Realisation '{branch_id}' must be a dictionary object.")
-        required_keys = ["name", "path"]
-        if any(key not in branch_config for key in required_keys):
+        if "path" not in branch_config:
             raise ValueError(
-                f"Realisation '{branch_id}' does not list all required "
-                "entries. Those are: "
-                ", ".join(required_keys)
-            )
-        if not isinstance(branch_config["name"], str):
-            raise TypeError(
-                f"The 'name' field in realisation '{branch_id}' must be a " "string."
+                f"Realisation '{branch_id}' must specify the `path` field."
             )
         if not isinstance(branch_config["path"], str):
             raise TypeError(
-                f"The 'path' field in realisation '{branch_id}' must be a " "string."
+                f"The 'path' field in realisation '{branch_id}' must be a string."
+            )
+        # the "name" key is optional
+        if "name" in branch_config and not isinstance(branch_config["name"], str):
+            raise TypeError(
+                f"The 'name' field in realisation '{branch_id}' must be a string."
             )
         # the "revision" key is optional
         if "revision" in branch_config and not isinstance(
@@ -111,6 +109,8 @@ def read_config(config_path: str) -> dict:
     check_config(config)
 
     for branch in config["realisations"]:
+        # Add "name" key if not provided and set to base name of "path" key
+        branch.setdefault("name", Path(branch["path"]).name)
         # Add "revision" key if not provided and set to default value -1, i.e. HEAD of branch
         branch.setdefault("revision", -1)
         # Add "patch" key if not provided and set to default value {}

--- a/benchcab/bench_config.py
+++ b/benchcab/bench_config.py
@@ -15,18 +15,16 @@ def check_config(config: dict):
     If the config is invalid, an exception is raised. Otherwise, do nothing.
     """
 
-    required_keys = ['realisations', 'project', 'user', 'modules', 'experiment']
+    required_keys = ["realisations", "project", "modules", "experiment"]
     if any(key not in config for key in required_keys):
         raise ValueError(
             "The config file does not list all required entries. "
-            "Those are: " ", ".join(required_keys)
+            "Those are: "
+            ", ".join(required_keys)
         )
 
     if not isinstance(config["project"], str):
         raise TypeError("The 'project' key must be a string.")
-
-    if not isinstance(config["user"], str):
-        raise TypeError("The 'user' key must be a string.")
 
     if not isinstance(config["modules"], list):
         raise TypeError("The 'modules' key must be a list.")
@@ -40,7 +38,9 @@ def check_config(config: dict):
             raise TypeError("The 'science_configurations' key must be a list.")
         if config["science_configurations"] == []:
             raise ValueError("The 'science_configurations' key cannot be empty.")
-        if not all(isinstance(value, dict) for value in config["science_configurations"]):
+        if not all(
+            isinstance(value, dict) for value in config["science_configurations"]
+        ):
             raise TypeError(
                 "Science config settings must be specified using a dictionary "
                 "that is compatible with the f90nml python package."
@@ -50,7 +50,8 @@ def check_config(config: dict):
     if config["experiment"] not in valid_experiments:
         raise ValueError(
             "The 'experiment' key is invalid.\n"
-            "Valid experiments are: " ", ".join(valid_experiments)
+            "Valid experiments are: "
+            ", ".join(valid_experiments)
         )
 
     if not isinstance(config["realisations"], list):
@@ -59,35 +60,31 @@ def check_config(config: dict):
     if config["realisations"] == []:
         raise ValueError("The 'realisations' key cannot be empty.")
 
-    for branch_id, branch_config in enumerate(config['realisations']):
+    for branch_id, branch_config in enumerate(config["realisations"]):
         if not isinstance(branch_config, dict):
             raise TypeError(f"Realisation '{branch_id}' must be a dictionary object.")
-        required_keys = ["name", "trunk", "share_branch"]
+        required_keys = ["name", "path"]
         if any(key not in branch_config for key in required_keys):
             raise ValueError(
                 f"Realisation '{branch_id}' does not list all required "
-                "entries. Those are: " ", ".join(required_keys)
+                "entries. Those are: "
+                ", ".join(required_keys)
             )
         if not isinstance(branch_config["name"], str):
             raise TypeError(
-                f"The 'name' field in realisation '{branch_id}' must be a "
-                "string."
+                f"The 'name' field in realisation '{branch_id}' must be a " "string."
+            )
+        if not isinstance(branch_config["path"], str):
+            raise TypeError(
+                f"The 'path' field in realisation '{branch_id}' must be a " "string."
             )
         # the "revision" key is optional
-        if "revision" in branch_config and not isinstance(branch_config["revision"], int):
+        if "revision" in branch_config and not isinstance(
+            branch_config["revision"], int
+        ):
             raise TypeError(
                 f"The 'revision' field in realisation '{branch_id}' must be an "
                 "integer."
-            )
-        if not isinstance(branch_config["trunk"], bool):
-            raise TypeError(
-                f"The 'trunk' field in realisation '{branch_id}' must be a "
-                "boolean."
-            )
-        if not isinstance(branch_config["share_branch"], bool):
-            raise TypeError(
-                f"The 'share_branch' field in realisation '{branch_id}' must be a "
-                "boolean."
             )
         # the "patch" key is optional
         if "patch" in branch_config and not isinstance(branch_config["patch"], dict):
@@ -95,9 +92,10 @@ def check_config(config: dict):
                 f"The 'patch' field in realisation '{branch_id}' must be a "
                 "dictionary that is compatible with the f90nml python package."
             )
-
         # the "build_script" key is optional
-        if "build_script" in branch_config and not isinstance(branch_config["build_script"], str):
+        if "build_script" in branch_config and not isinstance(
+            branch_config["build_script"], str
+        ):
             raise TypeError(
                 f"The 'build_script' field in realisation '{branch_id}' must be a "
                 "string."
@@ -112,13 +110,13 @@ def read_config(config_path: str) -> dict:
 
     check_config(config)
 
-    for branch in config['realisations']:
+    for branch in config["realisations"]:
         # Add "revision" key if not provided and set to default value -1, i.e. HEAD of branch
-        branch.setdefault('revision', -1)
+        branch.setdefault("revision", -1)
         # Add "patch" key if not provided and set to default value {}
-        branch.setdefault('patch', {})
+        branch.setdefault("patch", {})
         # Add "build_script" key if not provided and set to default value ""
-        branch.setdefault('build_script', "")
+        branch.setdefault("build_script", "")
 
     # Add "science_configurations" if not provided and set to default value
     config.setdefault("science_configurations", DEFAULT_SCIENCE_CONFIGURATIONS)

--- a/benchcab/benchcab.py
+++ b/benchcab/benchcab.py
@@ -53,7 +53,7 @@ class Benchcab:
         setup_src_dir()
         print("Checking out repositories...")
         for branch in self.config["realisations"]:
-            checkout_cable(branch, self.config["user"], verbose=self.args.verbose)
+            checkout_cable(branch, verbose=self.args.verbose)
         checkout_cable_auxiliary(self.args.verbose)
         archive_rev_number()
         print("")
@@ -96,7 +96,6 @@ class Benchcab:
         else:
             create_job_script(
                 project=self.config["project"],
-                user=self.config["user"],
                 config_path=self.args.config,
                 modules=self.config["modules"],
                 verbose=self.args.verbose,

--- a/benchcab/get_cable.py
+++ b/benchcab/get_cable.py
@@ -35,7 +35,7 @@ def next_path(path_pattern, sep="-"):
     new_file_index = 1
     common_filename, _ = loc_pattern.stem.split(sep)
 
-    pattern_files_sorted = sorted(Path('.').glob(path_pattern))
+    pattern_files_sorted = sorted(Path(".").glob(path_pattern))
     if len(pattern_files_sorted):
         common_filename, last_file_index = pattern_files_sorted[-1].stem.split(sep)
         new_file_index = int(last_file_index) + 1
@@ -90,30 +90,33 @@ def checkout_cable_auxiliary(verbose=False):
         print(cmd)
 
     subprocess.run(
-        cmd,
-        shell=True,
-        check=True,
-        stdout=None if verbose else subprocess.DEVNULL
+        cmd, shell=True, check=True, stdout=None if verbose else subprocess.DEVNULL
     )
 
     # Check relevant files exist in repository:
 
     if not Path.exists(CWD / internal.GRID_FILE):
-        raise RuntimeError(f"Error checking out CABLE-AUX: cannot find file '{internal.GRID_FILE}'")
+        raise RuntimeError(
+            f"Error checking out CABLE-AUX: cannot find file '{internal.GRID_FILE}'"
+        )
 
     if not Path.exists(CWD / internal.PHEN_FILE):
-        raise RuntimeError(f"Error checking out CABLE-AUX: cannot find file '{internal.PHEN_FILE}'")
+        raise RuntimeError(
+            f"Error checking out CABLE-AUX: cannot find file '{internal.PHEN_FILE}'"
+        )
 
     if not Path.exists(CWD / internal.CNPBIOME_FILE):
         raise RuntimeError(
             f"Error checking out CABLE-AUX: cannot find file '{internal.CNPBIOME_FILE}'"
         )
 
-    rev_number = svn_info_show_item(f"{CABLE_SVN_ROOT}/branches/Share/CABLE-AUX", "revision")
+    rev_number = svn_info_show_item(
+        f"{CABLE_SVN_ROOT}/branches/Share/CABLE-AUX", "revision"
+    )
     print(f"Successfully checked out CABLE-AUX at revision {rev_number}")
 
 
-def checkout_cable(branch_config: dict, user: str, verbose=False):
+def checkout_cable(branch_config: dict, verbose=False):
     """Checkout a branch of CABLE."""
     # TODO(Sean) do nothing if the repository has already been checked out?
     # This also relates the 'clean' feature.
@@ -124,18 +127,11 @@ def checkout_cable(branch_config: dict, user: str, verbose=False):
     if branch_config["revision"] > 0:
         cmd += f" -r {branch_config['revision']}"
 
-    if branch_config["trunk"]:
-        path_to_repo = Path(CWD, SRC_DIR, "trunk")
-        cmd += f" {CABLE_SVN_ROOT}/trunk {path_to_repo}"
-    elif branch_config["share_branch"]:
-        path_to_repo = Path(CWD, SRC_DIR, branch_config["name"])
-        cmd += f" {CABLE_SVN_ROOT}/branches/Share/{branch_config['name']} {path_to_repo}"
-    else:
-        path_to_repo = Path(CWD, SRC_DIR, branch_config["name"])
-        cmd += f" {CABLE_SVN_ROOT}/branches/Users/{user}/{branch_config['name']} {path_to_repo}"
-
     if need_pass():
         cmd += f" --password {get_password()}"
+
+    path_to_repo = Path(CWD, SRC_DIR, branch_config["name"])
+    cmd += f" {CABLE_SVN_ROOT}/{branch_config['path']} {path_to_repo}"
 
     if verbose:
         print(cmd)
@@ -150,7 +146,9 @@ def checkout_cable(branch_config: dict, user: str, verbose=False):
     # Write last change revision number to rev_number.log file
     last_changed_rev_number = svn_info_show_item(path_to_repo, "last-changed-revision")
     with open(f"{CWD}/rev_number.log", "a", encoding="utf-8") as fout:
-        fout.write(f"{branch_config['name']} last changed revision: {last_changed_rev_number}\n")
+        fout.write(
+            f"{branch_config['name']} last changed revision: {last_changed_rev_number}\n"
+        )
 
     rev_number = svn_info_show_item(path_to_repo, "revision")
     print(f"Successfully checked out {branch_config['name']} at revision {rev_number}")

--- a/benchcab/job_script.py
+++ b/benchcab/job_script.py
@@ -8,12 +8,9 @@ from pathlib import Path
 from benchcab.internal import QSUB_FNAME, NCPUS, MEM, WALL_TIME
 
 
-def create_job_script(
-    project: str, user: str, config_path: str, modules: list, verbose=False
-):
+def create_job_script(project: str, config_path: str, modules: list, verbose=False):
     """Creates a job script for executing `benchsiterun` on Gadi."""
 
-    email_address = f"{user}@nci.org.au"
     module_load_lines = "\n".join(
         f"module add {module_name}" for module_name in modules
     )
@@ -44,7 +41,6 @@ def create_job_script(
 #PBS -q normal
 #PBS -P {project}
 #PBS -j oe
-#PBS -M {email_address}
 #PBS -l storage=gdata/ks32+gdata/hh5+gdata/{project}+{curdir_root}/{curdir_proj}
 
 module purge

--- a/benchcab/job_script.py
+++ b/benchcab/job_script.py
@@ -41,6 +41,7 @@ def create_job_script(project: str, config_path: str, modules: list, verbose=Fal
 #PBS -q normal
 #PBS -P {project}
 #PBS -j oe
+#PBS -m e
 #PBS -l storage=gdata/ks32+gdata/hh5+gdata/{project}+{curdir_root}/{curdir_proj}
 
 module purge

--- a/docs/user_guide/config_options.md
+++ b/docs/user_guide/config_options.md
@@ -35,10 +35,6 @@ The different running modes of `benchcab` are solely dependent on the options us
 
 ## Technical options
 
-### `user`
-
-: NCI user ID to find the CABLE branch on SVN and run the simulations.
-
 ### `project`
 
 : NCI project ID to charge the simulations to.
@@ -53,21 +49,18 @@ The different running modes of `benchcab` are solely dependent on the options us
 
 : Entries for each CABLE branch to use. Each entry is a dictionary, `{}`, that contains the following keys:
 
+#### `path`
+
+: The path of the branch relative to the SVN root of the CABLE repository (`https://trac.nci.org.au/svn/cable`).
+: Example:
+
+    - to checkout `https://trac.nci.org.au/svn/cable/trunk`, set `path: "trunk"`
+    - to checkout `https://trac.nci.org.au/svn/cable/branches/Users/foo/my_branch`, set `path: "branches/Users/foo/my_branch"`
+
 #### `name`
 
-: The base name of the branch on SVN, i.e. relative to:
-
-    - `https://trac.nci.org.au/svn/cable` for the trunk
-    - `https://trac.nci.org.au/svn/cable/branches/Share` for a shared branch
-    - `https://trac.nci.org.au/svn/cable/branches/Users/{user_id}` for a user branch
-
-#### `trunk`
-
-: Boolean value set to `True` if this branch is the trunk for CABLE. Else set to `False`.
-
-#### `share_branch`
-
-: Boolean value set to `True` if this branch is under `branches/Share` in the CABLE SVN repository. Else set to `False`.
+: An alias name used internally by `benchcab` for the branch. The `name` key also specifies the directory name when checking out the branch, that is, `name` is the optional `PATH` argument to `svn checkout`.
+: This key is **optional** and can be omitted from the config file. By default `name` is set to the base name of [`path`](#`path`).
 
 #### `build_script`
 
@@ -89,16 +82,10 @@ Example:
 ```yaml
 realisations: [
   { # head of the trunk
-    name: "trunk",
-    revision: -1,
-    trunk: True,
-    share_branch: False,
+    path: "trunk",
   },
   { # some development branch
-    name: "test-branch",
-    revision: -1,
-    trunk: False,
-    share_branch: False,
+    path: "branches/Users/foo/my_branch",
     patch: {
       cable: {
         cable_user: {

--- a/tests/common.py
+++ b/tests/common.py
@@ -9,7 +9,6 @@ TMP_DIR = Path(os.environ["TMPDIR"], "benchcab_tests")
 def make_barebones_config() -> dict:
     """Returns a valid mock config."""
     conf = {
-        "user": "foo1234",
         "project": "bar",
         "experiment": "five-site-test",
         "modules": [
@@ -21,19 +20,15 @@ def make_barebones_config() -> dict:
             {
                 "name": "trunk",
                 "revision": 9000,
-                "trunk": True,
-                "share_branch": False,
+                "path": "trunk",
                 "patch": {},
                 "build_script": "",
             },
             {
                 "name": "v3.0-YP-changes",
                 "revision": -1,
-                "trunk": False,
-                "share_branch": False,
-                "patch": {
-                    "cable": {"cable_user": {"ENABLE_SOME_FEATURE": False}}
-                },
+                "path": "branches/Users/sean/my-branch",
+                "patch": {"cable": {"cable_user": {"ENABLE_SOME_FEATURE": False}}},
                 "build_script": "",
             },
         ],
@@ -54,6 +49,6 @@ def make_barebones_config() -> dict:
                     }
                 }
             },
-        ]
+        ],
     }
     return conf

--- a/tests/test_bench_config.py
+++ b/tests/test_bench_config.py
@@ -29,12 +29,12 @@ def test_check_config():
 
     # Success case: test config when realisations contains more than two keys
     config = make_barebones_config()
-    config["realisations"].append({
-        "name": "my_new_branch",
-        "revision": -1,
-        "trunk": False,
-        "share_branch": False,
-    })
+    config["realisations"].append(
+        {
+            "name": "my_new_branch",
+            "path": "path/to/my_new_branch",
+        }
+    )
     assert len(config["realisations"]) > 2
     check_config(config)
 
@@ -59,12 +59,6 @@ def test_check_config():
     with pytest.raises(ValueError):
         config = make_barebones_config()
         config.pop("project")
-        check_config(config)
-
-    # Failure case: test config without user key raises an exception
-    with pytest.raises(ValueError):
-        config = make_barebones_config()
-        config.pop("user")
         check_config(config)
 
     # Failure case: test config without realisations key raises an exception
@@ -110,16 +104,10 @@ def test_check_config():
         config["realisations"][1].pop("name")
         check_config(config)
 
-    # Failure case: 'trunk' key is missing in branch configuration
+    # Failure case: 'path' key is missing in branch configuration
     with pytest.raises(ValueError):
         config = make_barebones_config()
-        config["realisations"][1].pop("trunk")
-        check_config(config)
-
-    # Failure case: 'share_branch' key is missing in branch configuration
-    with pytest.raises(ValueError):
-        config = make_barebones_config()
-        config["realisations"][1].pop("share_branch")
+        config["realisations"][1].pop("path")
         check_config(config)
 
     # Failure case: test config with empty science_configurations key
@@ -127,12 +115,6 @@ def test_check_config():
     with pytest.raises(ValueError):
         config = make_barebones_config()
         config["science_configurations"] = []
-        check_config(config)
-
-    # Failure case: user key is not a string
-    with pytest.raises(TypeError):
-        config = make_barebones_config()
-        config["user"] = 123
         check_config(config)
 
     # Failure case: project key is not a string
@@ -153,6 +135,36 @@ def test_check_config():
         config["realisations"] = ["foo", "bar"]
         check_config(config)
 
+    # Failure case: type of name is not a string
+    with pytest.raises(TypeError):
+        config = make_barebones_config()
+        config["realisations"][1]["name"] = 1234
+        check_config(config)
+
+    # Failure case: type of path is not a string
+    with pytest.raises(TypeError):
+        config = make_barebones_config()
+        config["realisations"][1]["path"] = 1234
+        check_config(config)
+
+    # Failure case: type of revision key is not an integer
+    with pytest.raises(TypeError):
+        config = make_barebones_config()
+        config["realisations"][1]["revision"] = "-1"
+        check_config(config)
+
+    # Failure case: type of patch key is not a dictionary
+    with pytest.raises(TypeError):
+        config = make_barebones_config()
+        config["realisations"][1]["patch"] = r"cable_user%ENABLE_SOME_FEATURE = .FALSE."
+        check_config(config)
+
+    # Failure case: type of build_script key is not a string
+    with pytest.raises(TypeError):
+        config = make_barebones_config()
+        config["realisations"][1]["build_script"] = ["echo", "hello"]
+        check_config(config)
+
     # Failure case: modules key is not a list
     with pytest.raises(TypeError):
         config = make_barebones_config()
@@ -165,27 +177,6 @@ def test_check_config():
         config["experiment"] = 0
         check_config(config)
 
-    # Failure case: type of config["branch"]["revision"] is
-    # not an integer
-    with pytest.raises(TypeError):
-        config = make_barebones_config()
-        config["realisations"][1]["revision"] = "-1"
-        check_config(config)
-
-    # Failure case: type of config["branch"]["trunk"] is
-    # not an boolean
-    with pytest.raises(TypeError):
-        config = make_barebones_config()
-        config["realisations"][1]["trunk"] = 0
-        check_config(config)
-
-    # Failure case: type of config["branch"]["share_branch"] is
-    # not a boolean
-    with pytest.raises(TypeError):
-        config = make_barebones_config()
-        config["realisations"][1]["share_branch"] = "0"
-        check_config(config)
-
     # Failure case: type of config["science_configurations"] is not a list
     with pytest.raises(TypeError):
         config = make_barebones_config()
@@ -196,12 +187,6 @@ def test_check_config():
     with pytest.raises(TypeError):
         config = make_barebones_config()
         config["science_configurations"] = [r"cable_user%GS_SWITCH = 'medlyn'"]
-        check_config(config)
-
-    # Failure case: type of patch key is not a dictionary
-    with pytest.raises(TypeError):
-        config = make_barebones_config()
-        config["realisations"][1]["patch"] = r"cable_user%ENABLE_SOME_FEATURE = .FALSE."
         check_config(config)
 
 


### PR DESCRIPTION
The user should be able to checkout branches of other users so that test suites can be reproduced by any user.

This change lets the user specify the path relative to the SVN root of the CABLE repository for each branch by specifying the `path` key in the configuration file. Remove the `trunk` and `share_branch` keys from the configuration file as this information is contained within `path`.

This change repurposes the `name` key for each branch to be an alias used internally by benchcab. This lets the user specify the directory name when checking out the branch, that is, `name` is the optional `PATH` argument to svn checkout`. This is useful in the case that we have a collision in branch names when checking out multiple branches.

Remove the `-M` PBS argument for sending emails in the job script as the default behaviour is sufficient.

Remove the `user` key as this is now redundant.

Update unit tests for `check_config()`.

Fixes #61