### PR TITLE
Fix CABLE non-zero exit code behaviour

### DIFF
--- a/benchcab/run_cable_site.py
+++ b/benchcab/run_cable_site.py
@@ -29,7 +29,7 @@ from benchcab.internal import (
     CABLE_EXE,
     CABLE_NML,
     CABLE_STDOUT_FILENAME,
-    NUM_CORES
+    NUM_CORES,
 )
 from benchcab.task import Task
 
@@ -62,20 +62,23 @@ def run_tasks(tasks: list[Task], verbose=False):
         task_name = task.get_task_name()
         task_dir = CWD / SITE_TASKS_DIR / task_name
         if verbose:
-            print(f"Running task {task_name}... CABLE standard output "
-                  f"saved in {task_dir / CABLE_STDOUT_FILENAME}")
+            print(
+                f"Running task {task_name}... CABLE standard output "
+                f"saved in {task_dir / CABLE_STDOUT_FILENAME}"
+            )
 
         if verbose:
             print(f"  cd {task_dir}")
         os.chdir(task_dir)
 
-        cmd = f"./{CABLE_EXE} {CABLE_NML} > {CABLE_STDOUT_FILENAME}"
+        cmd = f"./{CABLE_EXE} {CABLE_NML} > {CABLE_STDOUT_FILENAME} 2>&1"
         try:
             if verbose:
                 print(f"  {cmd}")
             subprocess.run(cmd, shell=True, check=True)
-        except subprocess.CalledProcessError as err:
-            print("Job failed to submit: ", err.cmd)
+        except subprocess.CalledProcessError:
+            print(f"Error: CABLE returned a non-zero exit code for task {task_name}")
+            continue
 
         output_file = CWD / SITE_OUTPUT_DIR / task.get_output_filename()
         if verbose:


### PR DESCRIPTION
This commit fixes the following bugs in `run_tasks()`:
- If `subprocess.run` raises an exception, we still attempt to add attributes to the netcdf file. This change fixes this by continuing to the next task immediately on failure.
- The command to run CABLE does not redirect the stderr stream of CABLE. As a result, error messages are printed to the stderr of `benchcab`. This change fixes this by redirecting the CABLE stderr to its stdout stream so that the stderr from CABLE is written to `out.txt`.
- The error message "Job failed to submit: <cmd>" is printed when CABLE exits with a non-zero exit code which is misleading. This change updates the error message to state that CABLE has failed and the task name of the failed task.

Fixes #56