### PR TITLE
Specify absolute path to benchcab executable

### DIFF
--- a/benchcab/benchcab.py
+++ b/benchcab/benchcab.py
@@ -38,6 +38,7 @@ class Benchcab:
     def __init__(
         self,
         argv: list[str],
+        benchcab_exe_path: Optional[Path],
         config: Optional[dict] = None,
         validate_env: bool = True,
     ) -> None:
@@ -48,7 +49,7 @@ class Benchcab:
             for id, config in enumerate(self.config["realisations"])
         ]
         self.tasks: list[Task] = []  # initialise fluxsite tasks lazily
-        self.benchcab_exe_path = shutil.which(argv[0])
+        self.benchcab_exe_path = benchcab_exe_path
 
         if validate_env:
             self._validate_environment(
@@ -120,6 +121,9 @@ class Benchcab:
     def fluxsite_submit_job(self) -> None:
         """Submits the PBS job script step in the fluxsite test workflow."""
 
+        if self.benchcab_exe_path is None:
+            raise RuntimeError("Path to benchcab executable is undefined.")
+
         job_script_path = self.root_dir / internal.QSUB_FNAME
         print(
             "Creating PBS job script to run fluxsite tasks on compute "
@@ -133,9 +137,7 @@ class Benchcab:
                 storage_flags=[],  # TODO(Sean) add storage flags option to config
                 verbose=self.args.verbose,
                 skip_bitwise_cmp="fluxsite-bitwise-cmp" in self.args.skip,
-                benchcab_path=self.benchcab_exe_path
-                if self.benchcab_exe_path
-                else "benchcab",
+                benchcab_path=str(self.benchcab_exe_path),
             )
             file.write(contents)
 
@@ -293,7 +295,7 @@ def main():
     This is required for setup.py entry_points
     """
 
-    app = Benchcab(argv=sys.argv)
+    app = Benchcab(argv=sys.argv, benchcab_exe_path=shutil.which(sys.argv[0]))
     app.main()
 
 

--- a/benchcab/benchcab.py
+++ b/benchcab/benchcab.py
@@ -3,6 +3,7 @@
 import sys
 import os
 import grp
+import shutil
 from pathlib import Path
 from typing import Optional
 from subprocess import CalledProcessError
@@ -47,6 +48,7 @@ class Benchcab:
             for id, config in enumerate(self.config["realisations"])
         ]
         self.tasks: list[Task] = []  # initialise fluxsite tasks lazily
+        self.benchcab_exe_path = shutil.which(argv[0])
 
         if validate_env:
             self._validate_environment(
@@ -131,6 +133,9 @@ class Benchcab:
                 storage_flags=[],  # TODO(Sean) add storage flags option to config
                 verbose=self.args.verbose,
                 skip_bitwise_cmp="fluxsite-bitwise-cmp" in self.args.skip,
+                benchcab_path=self.benchcab_exe_path
+                if self.benchcab_exe_path
+                else "benchcab",
             )
             file.write(contents)
 

--- a/benchcab/utils/pbs.py
+++ b/benchcab/utils/pbs.py
@@ -10,6 +10,7 @@ def render_job_script(
     storage_flags: list,
     verbose=False,
     skip_bitwise_cmp=False,
+    benchcab_path="benchcab",
 ) -> str:
     """Returns the text for a PBS job script that executes all computationally expensive commands.
 
@@ -34,17 +35,15 @@ def render_job_script(
 #PBS -l storage={'+'.join(storage_flags)}
 
 module purge
-module use /g/data/hh5/public/modules
-module load conda/analysis3-unstable
 {module_load_lines}
 
-benchcab fluxsite-run-tasks --config={config_path} {verbose_flag}
+{benchcab_path} fluxsite-run-tasks --config={config_path} {verbose_flag}
 if [ $? -ne 0 ]; then
     echo 'Error: benchcab fluxsite-run-tasks failed. Exiting...'
     exit 1
 fi
 {'' if skip_bitwise_cmp else f'''
-benchcab fluxsite-bitwise-cmp --config={config_path} {verbose_flag}
+{benchcab_path} fluxsite-bitwise-cmp --config={config_path} {verbose_flag}
 if [ $? -ne 0 ]; then
     echo 'Error: benchcab fluxsite-bitwise-cmp failed. Exiting...'
     exit 1

--- a/benchcab/utils/pbs.py
+++ b/benchcab/utils/pbs.py
@@ -8,9 +8,9 @@ def render_job_script(
     config_path: str,
     modules: list,
     storage_flags: list,
+    benchcab_path: str,
     verbose=False,
     skip_bitwise_cmp=False,
-    benchcab_path="benchcab",
 ) -> str:
     """Returns the text for a PBS job script that executes all computationally expensive commands.
 

--- a/tests/test_benchcab.py
+++ b/tests/test_benchcab.py
@@ -3,6 +3,7 @@
 import contextlib
 import io
 from subprocess import CalledProcessError
+from pathlib import Path
 import pytest
 
 from benchcab.benchcab import Benchcab
@@ -16,7 +17,12 @@ def get_mock_app(
 ) -> Benchcab:
     """Returns a mock `Benchcab` instance for testing against."""
     config = get_mock_config()
-    app = Benchcab(argv=["benchcab", "fluxsite"], config=config, validate_env=False)
+    app = Benchcab(
+        argv=["benchcab", "fluxsite"],
+        benchcab_exe_path=Path("/path/to/benchcab"),
+        config=config,
+        validate_env=False,
+    )
     app.subprocess_handler = subprocess_handler
     app.root_dir = MOCK_CWD
     return app
@@ -59,3 +65,9 @@ def test_fluxsite_submit_job():
         f"nodes: {internal.QSUB_FNAME}\n"
         f"Error when submitting job to NCI queue\n{mock_subprocess.stdout}\n"
     )
+
+    # Failure case: test exception is raised when benchcab_exe_path is None
+    app = get_mock_app()
+    app.benchcab_exe_path = None
+    with pytest.raises(RuntimeError, match="Path to benchcab executable is undefined."):
+        app.fluxsite_submit_job()

--- a/tests/test_pbs.py
+++ b/tests/test_pbs.py
@@ -26,8 +26,6 @@ def test_render_job_script():
 #PBS -l storage=gdata/ks32+gdata/hh5+gdata/tm70+scratch/tm70
 
 module purge
-module use /g/data/hh5/public/modules
-module load conda/analysis3-unstable
 module load foo
 module load bar
 module load baz
@@ -66,8 +64,6 @@ fi
 #PBS -l storage=gdata/ks32+gdata/hh5+gdata/tm70+scratch/tm70
 
 module purge
-module use /g/data/hh5/public/modules
-module load conda/analysis3-unstable
 module load foo
 module load bar
 module load baz
@@ -106,8 +102,6 @@ fi
 #PBS -l storage=gdata/ks32+gdata/hh5+gdata/tm70+scratch/tm70
 
 module purge
-module use /g/data/hh5/public/modules
-module load conda/analysis3-unstable
 module load foo
 module load bar
 module load baz
@@ -141,8 +135,6 @@ fi
 #PBS -l storage=gdata/ks32+gdata/hh5+gdata/tm70
 
 module purge
-module use /g/data/hh5/public/modules
-module load conda/analysis3-unstable
 module load foo
 module load bar
 module load baz
@@ -153,5 +145,43 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
+"""
+    )
+
+    # Success case: specify path to benchcab executable
+    assert render_job_script(
+        project="tm70",
+        config_path="/path/to/config.yaml",
+        modules=["foo", "bar", "baz"],
+        storage_flags=[],
+        benchcab_path="/absolute/path/to/benchcab",
+    ) == (
+        f"""#!/bin/bash
+#PBS -l wd
+#PBS -l ncpus={internal.NCPUS}
+#PBS -l mem={internal.MEM}
+#PBS -l walltime={internal.WALL_TIME}
+#PBS -q normal
+#PBS -P tm70
+#PBS -j oe
+#PBS -m e
+#PBS -l storage=gdata/ks32+gdata/hh5+gdata/tm70
+
+module purge
+module load foo
+module load bar
+module load baz
+
+/absolute/path/to/benchcab fluxsite-run-tasks --config=/path/to/config.yaml 
+if [ $? -ne 0 ]; then
+    echo 'Error: benchcab fluxsite-run-tasks failed. Exiting...'
+    exit 1
+fi
+
+/absolute/path/to/benchcab fluxsite-bitwise-cmp --config=/path/to/config.yaml 
+if [ $? -ne 0 ]; then
+    echo 'Error: benchcab fluxsite-bitwise-cmp failed. Exiting...'
+    exit 1
+fi
 """
     )

--- a/tests/test_pbs.py
+++ b/tests/test_pbs.py
@@ -13,6 +13,7 @@ def test_render_job_script():
         config_path="/path/to/config.yaml",
         modules=["foo", "bar", "baz"],
         storage_flags=["scratch/tm70"],
+        benchcab_path="/absolute/path/to/benchcab",
     ) == (
         f"""#!/bin/bash
 #PBS -l wd
@@ -30,13 +31,13 @@ module load foo
 module load bar
 module load baz
 
-benchcab fluxsite-run-tasks --config=/path/to/config.yaml 
+/absolute/path/to/benchcab fluxsite-run-tasks --config=/path/to/config.yaml 
 if [ $? -ne 0 ]; then
     echo 'Error: benchcab fluxsite-run-tasks failed. Exiting...'
     exit 1
 fi
 
-benchcab fluxsite-bitwise-cmp --config=/path/to/config.yaml 
+/absolute/path/to/benchcab fluxsite-bitwise-cmp --config=/path/to/config.yaml 
 if [ $? -ne 0 ]; then
     echo 'Error: benchcab fluxsite-bitwise-cmp failed. Exiting...'
     exit 1
@@ -51,6 +52,7 @@ fi
         modules=["foo", "bar", "baz"],
         storage_flags=["scratch/tm70"],
         verbose=True,
+        benchcab_path="/absolute/path/to/benchcab",
     ) == (
         f"""#!/bin/bash
 #PBS -l wd
@@ -68,13 +70,13 @@ module load foo
 module load bar
 module load baz
 
-benchcab fluxsite-run-tasks --config=/path/to/config.yaml -v
+/absolute/path/to/benchcab fluxsite-run-tasks --config=/path/to/config.yaml -v
 if [ $? -ne 0 ]; then
     echo 'Error: benchcab fluxsite-run-tasks failed. Exiting...'
     exit 1
 fi
 
-benchcab fluxsite-bitwise-cmp --config=/path/to/config.yaml -v
+/absolute/path/to/benchcab fluxsite-bitwise-cmp --config=/path/to/config.yaml -v
 if [ $? -ne 0 ]; then
     echo 'Error: benchcab fluxsite-bitwise-cmp failed. Exiting...'
     exit 1
@@ -89,6 +91,7 @@ fi
         modules=["foo", "bar", "baz"],
         storage_flags=["scratch/tm70"],
         skip_bitwise_cmp=True,
+        benchcab_path="/absolute/path/to/benchcab",
     ) == (
         f"""#!/bin/bash
 #PBS -l wd
@@ -106,7 +109,7 @@ module load foo
 module load bar
 module load baz
 
-benchcab fluxsite-run-tasks --config=/path/to/config.yaml 
+/absolute/path/to/benchcab fluxsite-run-tasks --config=/path/to/config.yaml 
 if [ $? -ne 0 ]; then
     echo 'Error: benchcab fluxsite-run-tasks failed. Exiting...'
     exit 1
@@ -122,38 +125,6 @@ fi
         modules=["foo", "bar", "baz"],
         storage_flags=[],
         skip_bitwise_cmp=True,
-    ) == (
-        f"""#!/bin/bash
-#PBS -l wd
-#PBS -l ncpus={internal.NCPUS}
-#PBS -l mem={internal.MEM}
-#PBS -l walltime={internal.WALL_TIME}
-#PBS -q normal
-#PBS -P tm70
-#PBS -j oe
-#PBS -m e
-#PBS -l storage=gdata/ks32+gdata/hh5+gdata/tm70
-
-module purge
-module load foo
-module load bar
-module load baz
-
-benchcab fluxsite-run-tasks --config=/path/to/config.yaml 
-if [ $? -ne 0 ]; then
-    echo 'Error: benchcab fluxsite-run-tasks failed. Exiting...'
-    exit 1
-fi
-
-"""
-    )
-
-    # Success case: specify path to benchcab executable
-    assert render_job_script(
-        project="tm70",
-        config_path="/path/to/config.yaml",
-        modules=["foo", "bar", "baz"],
-        storage_flags=[],
         benchcab_path="/absolute/path/to/benchcab",
     ) == (
         f"""#!/bin/bash
@@ -178,10 +149,5 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-/absolute/path/to/benchcab fluxsite-bitwise-cmp --config=/path/to/config.yaml 
-if [ $? -ne 0 ]; then
-    echo 'Error: benchcab fluxsite-bitwise-cmp failed. Exiting...'
-    exit 1
-fi
 """
     )


### PR DESCRIPTION
This change specifies the absolute path to the benchcab executable in the job script so that we don't run into path issues when running using a 'locally installed' version of benchcab. This will be helpful making code changes and testing them on NCI.

Fixes #95
