### PR TITLE
Run executable from task dir

### DIFF
--- a/benchcab/repository.py
+++ b/benchcab/repository.py
@@ -1,8 +1,6 @@
 """A module containing functions and data structures for manipulating CABLE repositories."""
 
 import shlex
-import contextlib
-import os
 import shutil
 import stat
 from pathlib import Path
@@ -11,17 +9,7 @@ from typing import Optional
 from benchcab import internal
 from benchcab.environment_modules import EnvironmentModulesInterface, EnvironmentModules
 from benchcab.utils.subprocess import SubprocessWrapperInterface, SubprocessWrapper
-
-
-@contextlib.contextmanager
-def chdir(newdir: Path):
-    """Context manager `cd`."""
-    prevdir = Path.cwd()
-    os.chdir(newdir.expanduser())
-    try:
-        yield
-    finally:
-        os.chdir(prevdir)
+from benchcab.utils.os import chdir
 
 
 class CableRepository:

--- a/benchcab/task.py
+++ b/benchcab/task.py
@@ -16,6 +16,7 @@ from benchcab import internal
 from benchcab.repository import CableRepository
 from benchcab.comparison import ComparisonTask
 from benchcab.utils.subprocess import SubprocessWrapperInterface, SubprocessWrapper
+from benchcab.utils.os import chdir
 
 
 # fmt: off
@@ -260,14 +261,15 @@ class Task:
         """
         task_name = self.get_task_name()
         task_dir = self.root_dir / internal.FLUXSITE_TASKS_DIR / task_name
-        exe_path = task_dir / internal.CABLE_EXE
-        nml_path = task_dir / internal.CABLE_NML
         stdout_path = task_dir / internal.CABLE_STDOUT_FILENAME
 
         try:
-            self.subprocess_handler.run_cmd(
-                f"{exe_path} {nml_path}", output_file=stdout_path, verbose=verbose
-            )
+            with chdir(task_dir):
+                self.subprocess_handler.run_cmd(
+                    f"./{internal.CABLE_EXE} {internal.CABLE_NML}",
+                    output_file=stdout_path,
+                    verbose=verbose,
+                )
         except CalledProcessError as exc:
             print(f"Error: CABLE returned an error for task {task_name}")
             raise CableError from exc

--- a/benchcab/utils/os.py
+++ b/benchcab/utils/os.py
@@ -1,0 +1,16 @@
+"""Utility functions which wrap around the os module."""
+
+import os
+import contextlib
+from pathlib import Path
+
+
+@contextlib.contextmanager
+def chdir(newdir: Path):
+    """Context manager `cd`."""
+    prevdir = Path.cwd()
+    os.chdir(newdir.expanduser())
+    try:
+        yield
+    finally:
+        os.chdir(prevdir)

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -295,7 +295,7 @@ def test_run_cable():
 
     # Success case: run CABLE executable in subprocess
     task.run_cable()
-    assert f"{exe_path} {nml_path}" in mock_subprocess.commands
+    assert f"./{exe_path.name} {nml_path.name}" in mock_subprocess.commands
     assert stdout_file.exists()
 
     # Success case: test non-verbose output

--- a/tests/test_task.py
+++ b/tests/test_task.py
@@ -286,16 +286,11 @@ def test_run_cable():
     task = get_mock_task(subprocess_handler=mock_subprocess)
     task_dir = MOCK_CWD / internal.FLUXSITE_TASKS_DIR / task.get_task_name()
     task_dir.mkdir(parents=True)
-    exe_path = task_dir / internal.CABLE_EXE
-    exe_path.touch()
-    nml_path = task_dir / internal.CABLE_NML
-    nml_path.touch()
-
-    stdout_file = task_dir / internal.CABLE_STDOUT_FILENAME
 
     # Success case: run CABLE executable in subprocess
     task.run_cable()
-    assert f"./{exe_path.name} {nml_path.name}" in mock_subprocess.commands
+    assert f"./{internal.CABLE_EXE} {internal.CABLE_NML}" in mock_subprocess.commands
+    stdout_file = task_dir / internal.CABLE_STDOUT_FILENAME
     assert stdout_file.exists()
 
     # Success case: test non-verbose output


### PR DESCRIPTION
Currently, the CABLE executable is run from the current working directory instead of the task directory by using the absolute path to the executable. However, we should be running the executable from the task directory (otherwise CABLE will complain it cannot find the soil and PFT namelist files). This was a bug that was introduced in #99.

This change makes it so we change into the task directory before running the CABLE executable.

Fixes #123