### PR TITLE
Add patch remove feature

### DIFF
--- a/benchcab/config.py
+++ b/benchcab/config.py
@@ -124,6 +124,14 @@ def check_config(config: dict):
                 f"The 'patch' field in realisation '{branch_id}' must be a "
                 "dictionary that is compatible with the f90nml python package."
             )
+        # the "patch_remove" key is optional
+        if "patch_remove" in branch_config and not isinstance(
+            branch_config["patch_remove"], dict
+        ):
+            raise TypeError(
+                f"The 'patch_remove' field in realisation '{branch_id}' must be a "
+                "dictionary that is compatible with the f90nml python package."
+            )
         # the "build_script" key is optional
         if "build_script" in branch_config and not isinstance(
             branch_config["build_script"], str

--- a/benchcab/repository.py
+++ b/benchcab/repository.py
@@ -25,6 +25,7 @@ class CableRepository:
         name: Optional[str] = None,
         revision: Optional[int] = None,
         patch: Optional[dict] = None,
+        patch_remove: Optional[dict] = None,
         build_script: Optional[str] = None,
         repo_id: Optional[int] = None,
     ) -> None:
@@ -32,6 +33,7 @@ class CableRepository:
         self.name = name if name else self.path.name
         self.revision = revision
         self.patch = patch
+        self.patch_remove = patch_remove
         self.build_script = build_script
         self._repo_id = repo_id
 

--- a/docs/user_guide/config_options.md
+++ b/docs/user_guide/config_options.md
@@ -120,13 +120,13 @@ fluxsite:
 #### `patch`
 
 : Branch-specific namelist settings for `cable.nml`. Settings specified in `patch` get "patched" to the base namelist settings used for both branches. Any namelist settings specified here will overwrite settings defined in the default namelist file and in the science configurations. This means these settings will be set as stipulated in the `patch` for this branch for all science configurations run by `benchcab`.
-: The `patch` key must be a dictionary like data structure that is compliant with the [`f90nml`][f90nml-github] python package.
+: The `patch` key must be a dictionary-like data structure that is compliant with the [`f90nml`][f90nml-github] python package.
 : This key is **optional** and can be omitted from the config file (in which case `patch` does not modify the namelist file).
 
 #### `patch_remove`
 
-: Specifies branch-specific namelist settings to be removed from the `cable.nml` namelist settings. The `patch_remove` key is similar to [`patch`](#`patch`) in the that these settings will be removed from the namelist file for this branch for all science configurations run by `benchcab`.
-: The `patch_remove` key must be a dictionary like data structure that is compliant with the [`f90nml`][f90nml-github] python package.
+: Specifies branch-specific namelist settings to be removed from the `cable.nml` namelist settings. When the `patch_remove` key is specified, the specified namelists are removed from all namelist files for this branch for all science configurations run by `benchcab`.
+: The `patch_remove` key must be a dictionary-like data structure that is compliant with the [`f90nml`][f90nml-github] python package. Note, when specifying a namelist parameter in `patch_remove`, the value of the namelist parameter is ignored.
 : This key is **optional** and can be omitted from the config file (in which case `patch_remove` does not modify the namelist file).
 
 Example:
@@ -143,7 +143,7 @@ realisations: [
           FWSOIL_SWITCH: "Lai and Ktaul 2000"
         }
       }
-    }
+    },
     patch_remove: {
       cable: {
         soilparmnew: nil

--- a/docs/user_guide/config_options.md
+++ b/docs/user_guide/config_options.md
@@ -123,6 +123,12 @@ fluxsite:
 : The `patch` key must be a dictionary like data structure that is compliant with the [`f90nml`][f90nml-github] python package.
 : This key is **optional** and can be omitted from the config file (in which case `patch` does not modify the namelist file).
 
+#### `patch_remove`
+
+: Specifies branch-specific namelist settings to be removed from the `cable.nml` namelist settings. The `patch_remove` key is similar to [`patch`](#`patch`) in the that these settings will be removed from the namelist file for this branch for all science configurations run by `benchcab`.
+: The `patch_remove` key must be a dictionary like data structure that is compliant with the [`f90nml`][f90nml-github] python package.
+: This key is **optional** and can be omitted from the config file (in which case `patch_remove` does not modify the namelist file).
+
 Example:
 ```yaml
 realisations: [
@@ -136,6 +142,11 @@ realisations: [
         cable_user: {
           FWSOIL_SWITCH: "Lai and Ktaul 2000"
         }
+      }
+    }
+    patch_remove: {
+      cable: {
+        soilparmnew: nil
       }
     }
   }

--- a/tests/common.py
+++ b/tests/common.py
@@ -27,6 +27,7 @@ def get_mock_config() -> dict:
                 "revision": 9000,
                 "path": "trunk",
                 "patch": {},
+                "patch_remove": {},
                 "build_script": "",
             },
             {
@@ -34,6 +35,7 @@ def get_mock_config() -> dict:
                 "revision": -1,
                 "path": "branches/Users/sean/my-branch",
                 "patch": {"cable": {"cable_user": {"ENABLE_SOME_FEATURE": False}}},
+                "patch_remove": {},
                 "build_script": "",
             },
         ],

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,6 +32,11 @@ def test_check_config():
     config["realisations"][0].pop("patch")
     check_config(config)
 
+    # Success case: branch configuration with missing patch_remove key
+    config = get_mock_config()
+    config["realisations"][0].pop("patch_remove")
+    check_config(config)
+
     # Success case: test config when realisations contains more than two keys
     config = get_mock_config()
     config["realisations"].append({"path": "path/to/my_new_branch"})
@@ -202,6 +207,16 @@ def test_check_config():
     ):
         config = get_mock_config()
         config["realisations"][1]["patch"] = r"cable_user%ENABLE_SOME_FEATURE = .FALSE."
+        check_config(config)
+
+    # Failure case: type of patch_remove key is not a dictionary
+    with pytest.raises(
+        TypeError,
+        match="The 'patch_remove' field in realisation '1' must be a dictionary that is "
+        "compatible with the f90nml python package.",
+    ):
+        config = get_mock_config()
+        config["realisations"][1]["patch_remove"] = r"cable_user%ENABLE_SOME_FEATURE"
         check_config(config)
 
     # Failure case: type of build_script key is not a string


### PR DESCRIPTION
Currently, `benchcab` does not support removing namelist parameters from the base namelist file. For example, legacy CABLE branches may not be compatible with a namelist parameter in the base namelist file.

This change adds a `patch_remove` key which will remove a given set of namelist parameters for a specific branch.

Fixes #92