### PR TITLE
Fix documentation errors

### DIFF
--- a/benchcab/internal.py
+++ b/benchcab/internal.py
@@ -141,7 +141,7 @@ DEFAULT_SCIENCE_CONFIGURATIONS = [
 # on modelevaluation.org
 MEORG_EXPERIMENTS = {
     # List of FLUXNET site ids associated with the 'Five site test'
-    # experiment (workspace: NRI Land testing), see:
+    # experiment (workspace: benchcab-evaluation), see:
     # https://modelevaluation.org/experiment/display/xNZx2hSvn4PMKAa9R
     "five-site-test": [
         "AU-Tum",
@@ -151,7 +151,7 @@ MEORG_EXPERIMENTS = {
         "US-Whs",
     ],
     # List of FLUXNET site ids associated with the 'Forty two site test'
-    # experiment (workspace: NRI Land testing), see:
+    # experiment (workspace: benchcab-evaluation), see:
     # https://modelevaluation.org/experiment/display/urTKSXEsojdvEPwdR
     "forty-two-site-test": [
         "AU-Tum",

--- a/docs/user_guide/config_options.md
+++ b/docs/user_guide/config_options.md
@@ -155,7 +155,7 @@ realisations: [
 
 ### `experiment`
 
-: Type of experiment to run. Experiments are defined in the **NRI Land testing** workspace on [modelevaluation.org][meorg]. This key specifies the met forcing files used in the test suite. To choose from:
+: Type of experiment to run. Experiments are defined in the **benchcab-evaluation** workspace on [modelevaluation.org][meorg]. This key specifies the met forcing files used in the test suite. To choose from:
 
     - [`forty-two-site-test`][forty-two-me]: to run simulations using 42 FLUXNET sites
     - [`five-site-test`][five-me]: to run simulations using 5 FLUXNET sites

--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -159,7 +159,7 @@ The following files and directories are created when `benchcab run` executes suc
 
 `runs/fluxsite/tasks`
 
-:   directory that contains task directories. CABLE runs are organised into tasks where a task consists of a branch (realisation), a meteorological forcing, and a science configuration. In the above directory structure, `<task>` uses the following naming convention:
+:   directory that contains task directories. A task consists of a CABLE run for a branch (realisation), a meteorological forcing, and a science configuration. In the above directory structure, `<task>` uses the following naming convention:
 
 ```
 <met_file_basename>_R<realisation_key>_S<science_config_key>

--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -157,9 +157,9 @@ The following files and directories are created when `benchcab run` executes suc
 
 :   directory that contains the log files, output files, and tasks for running CABLE. 
 
-`tasks`
+`runs/fluxsite/tasks`
 
-:   CABLE runs are organised into tasks where a task consists of a branch (realisation), a meteorological forcing, and a science configuration. In the above directory structure, `<task>` uses the following naming convention:
+:   directory that contains task directories. CABLE runs are organised into tasks where a task consists of a branch (realisation), a meteorological forcing, and a science configuration. In the above directory structure, `<task>` uses the following naming convention:
 
 ```
 <met_file_basename>_R<realisation_key>_S<science_config_key>


### PR DESCRIPTION
Fixes the following errors:
- [X] In user_guide.md - 'Directory structure and files', tasks should be runs/fluxsite/tasks.
- [X] In config_options.md - "NRI Land testing" should be "benchcab-evaluation"
- [X] In internal.py - "NRI Land testing" should be "benchcab-evaluation"

Fixes #131