### PR TITLE
Polish README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 [![Documentation status][readthedocs_badge]][docs] [![Test coverage][codecov_badge]][codecov_summary] [![Conda package status][conda_badge]][conda]
 
-`benchcab` is a testing framework that tests the CABLE land surface model across a range of model configurations and model versions. The tool checks out the model versions specified by the user, builds the required executables, and runs each model version across N standard science configurations. Model outputs are then piped into a benchmark analysis via [modelevaluation.org][meorg] from which the user can assess model performance.
+`benchcab` is a testing framework that tests the CABLE land surface model across a range of model configurations and model versions. The tool:
+- checks out the model versions specified by the user
+- builds the required executables
+- runs each model version across N standard science configurations
+- performs bitwise comparison checks on model outputs across model versions
+
+The user can then pipe the model outputs into a benchmark analysis via [modelevaluation.org][meorg] to assess model performance.
 
 The full documentation is available at [benchcab.readthedocs.io][docs].
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # benchcab
 
-[![codecov](https://codecov.io/gh/CABLE-LSM/benchcab/branch/master/graph/badge.svg?token=JJYE1YZDXQ)](https://codecov.io/gh/CABLE-LSM/benchcab)
+[![Documentation status][readthedocs_badge]][docs] [![Test coverage][codecov_badge]][codecov_summary] [![Conda package status][conda_badge]][conda]
 
 `benchcab` is a testing framework that tests the CABLE land surface model across a range of model configurations and model versions. The tool checks out the model versions specified by the user, builds the required executables, and runs each model version across N standard science configurations. Model outputs are then piped into a benchmark analysis via [modelevaluation.org][meorg] from which the user can assess model performance.
 
@@ -10,5 +10,10 @@ The full documentation is available at [benchcab.readthedocs.io][docs].
 
 - `benchcab` is a continuation of the efforts made by Martin De Kauwe ([@mdekauwe](https://github.com/mdekauwe)) and Gab Abramowitz ([@gabsun](https://github.com/gabsun)) in developing a CABLE benchmarking framework - we thank them for their contribution.
 
+[conda_badge]: https://img.shields.io/conda/v/accessnri/benchcab
+[codecov_badge]: https://codecov.io/gh/CABLE-LSM/benchcab/branch/master/graph/badge.svg?token=JJYE1YZDXQ
+[readthedocs_badge]: https://readthedocs.org/projects/benchcab/badge
+[conda]: https://anaconda.org/accessnri/benchcab
+[codecov_summary]: https://codecov.io/gh/CABLE-LSM/benchcab
 [docs]: https://benchcab.readthedocs.io
 [meorg]: https://modelevaluation.org

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# CABLE benchmarking
+# benchcab
 
 [![codecov](https://codecov.io/gh/CABLE-LSM/benchcab/branch/master/graph/badge.svg?token=JJYE1YZDXQ)](https://codecov.io/gh/CABLE-LSM/benchcab)
 
-Repository to benchmark CABLE. The benchmark will run the exact same configurations on two CABLE branches specified by the user, e.g. a user branch (with personal changes) against the head of the trunk. The results should be attached with all new [tickets](https://trac.nci.org.au/trac/cable/report/1).
+`benchcab` is a testing framework that tests the CABLE land surface model across a range of model configurations and model versions. The tool checks out the model versions specified by the user, builds the required executables, and runs each model version across N standard science configurations. Model outputs are then piped into a benchmark analysis via [modelevaluation.org][meorg] from which the user can assess model performance.
 
-The code will: (i) check out; (ii) build; and (iii) run branches across N standard science configurations. It is possible to produce some plots locally. But the outputs should be uploaded to [the modelevaluation website](https://modelevaluation.org/) for further benchmarking and evaluation.
+The full documentation is available at [benchcab.readthedocs.io][docs].
 
-For the moment, the benchmarking only works on NCI supercomputer.
+## Acknowledgements
 
-You can see the full documentation to use it at https://benchcab.readthedocs.io/en/latest/
+- `benchcab` is a continuation of the efforts made by Martin De Kauwe ([@mdekauwe](https://github.com/mdekauwe)) and Gab Abramowitz ([@gabsun](https://github.com/gabsun)) in developing a CABLE benchmarking framework - we thank them for their contribution.
 
-## Support
-Please leave your questions as [Issues](https://github.com/CABLE-LSM/benchcab/issues) to receive support
+[docs]: https://benchcab.readthedocs.io
+[meorg]: https://modelevaluation.org


### PR DESCRIPTION
- [X] Replace 'CABLE benchmarking' with benchcab
- [X] Update description of package. E.g. benchcab does not produce plots locally, it can run more than two branches, etc.
- [X] Documentation link shouldn't link to 'latest'
- [X] Add acknowledgements
- [X] Add badges for documentation and conda package (see #108)

Fixes #133