### PR TITLE
Added set -ex to the jobscript rendering, removed if statements. Fixe…

### DIFF
--- a/benchcab/utils/pbs.py
+++ b/benchcab/utils/pbs.py
@@ -47,18 +47,13 @@ def render_job_script(
 #PBS -m e
 #PBS -l storage={'+'.join(storage_flags)}
 
+set -ex
+
 module purge
 {module_load_lines}
 
 {benchcab_path} fluxsite-run-tasks --config={config_path} {verbose_flag}
-if [ $? -ne 0 ]; then
-    echo 'Error: benchcab fluxsite-run-tasks failed. Exiting...'
-    exit 1
-fi
 {'' if skip_bitwise_cmp else f'''
 {benchcab_path} fluxsite-bitwise-cmp --config={config_path} {verbose_flag}
-if [ $? -ne 0 ]; then
-    echo 'Error: benchcab fluxsite-bitwise-cmp failed. Exiting...'
-    exit 1
-fi''' }
+''' }
 """

--- a/tests/test_pbs.py
+++ b/tests/test_pbs.py
@@ -25,22 +25,17 @@ def test_render_job_script():
 #PBS -m e
 #PBS -l storage=gdata/ks32+gdata/hh5+gdata/tm70
 
+set -ex
+
 module purge
 module load foo
 module load bar
 module load baz
 
 /absolute/path/to/benchcab fluxsite-run-tasks --config=/path/to/config.yaml 
-if [ $? -ne 0 ]; then
-    echo 'Error: benchcab fluxsite-run-tasks failed. Exiting...'
-    exit 1
-fi
 
 /absolute/path/to/benchcab fluxsite-bitwise-cmp --config=/path/to/config.yaml 
-if [ $? -ne 0 ]; then
-    echo 'Error: benchcab fluxsite-bitwise-cmp failed. Exiting...'
-    exit 1
-fi
+
 """
     )
 
@@ -63,22 +58,17 @@ fi
 #PBS -m e
 #PBS -l storage=gdata/ks32+gdata/hh5+gdata/tm70
 
+set -ex
+
 module purge
 module load foo
 module load bar
 module load baz
 
 /absolute/path/to/benchcab fluxsite-run-tasks --config=/path/to/config.yaml -v
-if [ $? -ne 0 ]; then
-    echo 'Error: benchcab fluxsite-run-tasks failed. Exiting...'
-    exit 1
-fi
 
 /absolute/path/to/benchcab fluxsite-bitwise-cmp --config=/path/to/config.yaml -v
-if [ $? -ne 0 ]; then
-    echo 'Error: benchcab fluxsite-bitwise-cmp failed. Exiting...'
-    exit 1
-fi
+
 """
     )
 
@@ -101,16 +91,14 @@ fi
 #PBS -m e
 #PBS -l storage=gdata/ks32+gdata/hh5+gdata/tm70
 
+set -ex
+
 module purge
 module load foo
 module load bar
 module load baz
 
 /absolute/path/to/benchcab fluxsite-run-tasks --config=/path/to/config.yaml 
-if [ $? -ne 0 ]; then
-    echo 'Error: benchcab fluxsite-run-tasks failed. Exiting...'
-    exit 1
-fi
 
 """
     )
@@ -140,16 +128,14 @@ fi
 #PBS -m e
 #PBS -l storage=gdata/ks32+gdata/hh5+gdata/tm70+gdata/foo
 
+set -ex
+
 module purge
 module load foo
 module load bar
 module load baz
 
 /absolute/path/to/benchcab fluxsite-run-tasks --config=/path/to/config.yaml 
-if [ $? -ne 0 ]; then
-    echo 'Error: benchcab fluxsite-run-tasks failed. Exiting...'
-    exit 1
-fi
 
 """
     )
@@ -174,16 +160,14 @@ fi
 #PBS -m e
 #PBS -l storage=gdata/ks32+gdata/hh5+gdata/tm70
 
+set -ex
+
 module purge
 module load foo
 module load bar
 module load baz
 
 /absolute/path/to/benchcab fluxsite-run-tasks --config=/path/to/config.yaml 
-if [ $? -ne 0 ]; then
-    echo 'Error: benchcab fluxsite-run-tasks failed. Exiting...'
-    exit 1
-fi
 
 """
     )


### PR DESCRIPTION
Added set -ex to the header of the rendered jobscript. -x is used in place of explicit error messages as per the removed if statements, as it outputs all commands as they are being called so that we can see the exact line that the script fails.

In resolving this, the tests appear to be a bit flakey, relying on specific whitespace and line endings. I think this will be resolved as we move to Jinja2 templating (#142)

Fixes #158.