### PR TITLE
Removed numpy from benchcab-dev.yaml. Fixes #160

### DIFF
--- a/.conda/benchcab-dev.yaml
+++ b/.conda/benchcab-dev.yaml
@@ -6,7 +6,6 @@ dependencies:
   - python=3.9
   - f90nml
   - netcdf4
-  - numpy
   - pytest-cov
   - pyyaml
   - flatdict


### PR DESCRIPTION
Possibly the largest commit of the day.