### PR TITLE
Refactor work_dir creation

### DIFF
--- a/benchcab/benchcab.py
+++ b/benchcab/benchcab.py
@@ -11,7 +11,7 @@ from subprocess import CalledProcessError
 from benchcab import internal
 from benchcab.internal import get_met_forcing_file_names
 from benchcab.config import read_config
-from benchcab.workdir import fluxsite_directory_tree_list, setup_fluxsite_directory_tree, setup_src_dir
+from benchcab.workdir import setup_fluxsite_directory_tree
 from benchcab.repository import CableRepository
 from benchcab.fluxsite import (
     get_fluxsite_tasks,
@@ -25,7 +25,7 @@ from benchcab.cli import generate_parser
 from benchcab.environment_modules import EnvironmentModules, EnvironmentModulesInterface
 from benchcab.utils.subprocess import SubprocessWrapper, SubprocessWrapperInterface
 from benchcab.utils.pbs import render_job_script
-from benchcab.utils.fs import next_path
+from benchcab.utils.fs import next_path, mkdir, chdir
 
 
 class Benchcab:
@@ -163,7 +163,8 @@ class Benchcab:
     def checkout(self):
         """Endpoint for `benchcab checkout`."""
 
-        setup_src_dir()
+        with chdir(self.root_dir):
+            mkdir(internal.SRC_DIR, exist_ok=True, verbose=True)
 
         print("Checking out repositories...")
         rev_number_log = ""
@@ -215,9 +216,7 @@ class Benchcab:
         """Endpoint for `benchcab fluxsite-setup-work-dir`."""
         tasks = self.tasks if self.tasks else self._initialise_tasks()
         print("Setting up run directory tree for fluxsite tests...")
-        fluxsite_paths = fluxsite_directory_tree_list(
-            fluxsite_tasks=tasks)
-        setup_fluxsite_directory_tree(fluxsite_paths=fluxsite_paths, verbose=self.args.verbose)
+        setup_fluxsite_directory_tree(verbose=self.args.verbose)
         print("Setting up tasks...")
         for task in tasks:
             task.setup_task(verbose=self.args.verbose)

--- a/benchcab/benchcab.py
+++ b/benchcab/benchcab.py
@@ -22,7 +22,7 @@ from benchcab.fluxsite import (
 )
 from benchcab.internal import get_met_forcing_file_names
 from benchcab.repository import CableRepository
-from benchcab.utils.fs import next_path, mkdir
+from benchcab.utils.fs import mkdir, next_path
 from benchcab.utils.pbs import render_job_script
 from benchcab.utils.subprocess import SubprocessWrapper, SubprocessWrapperInterface
 from benchcab.workdir import setup_fluxsite_directory_tree
@@ -161,7 +161,6 @@ class Benchcab:
 
     def checkout(self):
         """Endpoint for `benchcab checkout`."""
-
         mkdir(internal.SRC_DIR, exist_ok=True, verbose=True)
 
         print("Checking out repositories...")

--- a/benchcab/benchcab.py
+++ b/benchcab/benchcab.py
@@ -11,7 +11,7 @@ from subprocess import CalledProcessError
 from benchcab import internal
 from benchcab.internal import get_met_forcing_file_names
 from benchcab.config import read_config
-from benchcab.workdir import setup_fluxsite_directory_tree, setup_src_dir
+from benchcab.workdir import fluxsite_directory_tree_list, setup_fluxsite_directory_tree, setup_src_dir
 from benchcab.repository import CableRepository
 from benchcab.fluxsite import (
     get_fluxsite_tasks,
@@ -215,7 +215,9 @@ class Benchcab:
         """Endpoint for `benchcab fluxsite-setup-work-dir`."""
         tasks = self.tasks if self.tasks else self._initialise_tasks()
         print("Setting up run directory tree for fluxsite tests...")
-        setup_fluxsite_directory_tree(fluxsite_tasks=tasks, verbose=self.args.verbose)
+        fluxsite_paths = fluxsite_directory_tree_list(
+            fluxsite_tasks=tasks)
+        setup_fluxsite_directory_tree(fluxsite_paths=fluxsite_paths, verbose=self.args.verbose)
         print("Setting up tasks...")
         for task in tasks:
             task.setup_task(verbose=self.args.verbose)

--- a/benchcab/benchcab.py
+++ b/benchcab/benchcab.py
@@ -20,8 +20,9 @@ from benchcab.fluxsite import (
     run_tasks,
     run_tasks_in_parallel,
 )
+from benchcab.internal import get_met_forcing_file_names
 from benchcab.repository import CableRepository
-from benchcab.utils.fs import next_path, mkdir, chdir
+from benchcab.utils.fs import next_path, mkdir
 from benchcab.utils.pbs import render_job_script
 from benchcab.utils.subprocess import SubprocessWrapper, SubprocessWrapperInterface
 from benchcab.workdir import setup_fluxsite_directory_tree
@@ -151,18 +152,17 @@ class Benchcab:
         print(
             f"PBS job submitted: {proc.stdout.strip()}\n"
             "The CABLE log file for each task is written to "
-            f"{internal.FLUXSITE_LOG_DIR}/<task_name>_log.txt\n"
+            f"{internal.FLUXSITE_DIRS['LOG']}/<task_name>_log.txt\n"
             "The CABLE standard output for each task is written to "
-            f"{internal.FLUXSITE_TASKS_DIR}/<task_name>/out.txt\n"
+            f"{internal.FLUXSITE_DIRS['TASKS']}/<task_name>/out.txt\n"
             "The NetCDF output for each task is written to "
-            f"{internal.FLUXSITE_OUTPUT_DIR}/<task_name>_out.nc"
+            f"{internal.FLUXSITE_DIRS['OUTPUT']}/<task_name>_out.nc"
         )
 
     def checkout(self):
         """Endpoint for `benchcab checkout`."""
 
-        with chdir(self.root_dir):
-            mkdir(internal.SRC_DIR, exist_ok=True, verbose=True)
+        mkdir(internal.SRC_DIR, exist_ok=True, verbose=True)
 
         print("Checking out repositories...")
         rev_number_log = ""

--- a/benchcab/comparison.py
+++ b/benchcab/comparison.py
@@ -39,7 +39,7 @@ class ComparisonTask:
         except CalledProcessError as exc:
             output_file = (
                 self.root_dir
-                / internal.FLUXSITE_BITWISE_CMP_DIR
+                / internal.FLUXSITE_DIRS["BITWISE_CMP"]
                 / f"{self.task_name}.txt"
             )
             with output_file.open("w", encoding="utf-8") as file:

--- a/benchcab/fluxsite.py
+++ b/benchcab/fluxsite.py
@@ -16,7 +16,7 @@ from benchcab import internal
 from benchcab.repository import CableRepository
 from benchcab.comparison import ComparisonTask
 from benchcab.utils.subprocess import SubprocessWrapperInterface, SubprocessWrapper
-from benchcab.utils.fs import chdir
+from benchcab.utils.fs import chdir, mkdir
 
 
 # fmt: off
@@ -132,16 +132,23 @@ class Task:
         """Does all file manipulations to run cable in the task directory.
 
         These include:
-        1. cleaning output, namelist, log files and cable executables if they exist
-        2. copying namelist files (cable.nml, pft_params.nml and cable_soil_parm.nml)
+        1. creating the task directory if it does not exist.
+        2. cleaning output, namelist, log files and cable executables if they exist
+        3. copying namelist files (cable.nml, pft_params.nml and cable_soil_parm.nml)
         into the `runs/fluxsite/tasks/<task_name>` directory.
-        3. copying the cable executable from the source directory
-        4. make appropriate adjustments to namelist files
-        5. apply a branch patch if specified
+        4. copying the cable executable from the source directory
+        5. make appropriate adjustments to namelist files
+        6. apply a branch patch if specified
         """
 
         if verbose:
             print(f"Setting up task: {self.get_task_name()}")
+
+        with chdir(self.root_dir):
+            mkdir(
+                internal.FLUXSITE_TASKS_DIR / self.get_task_name(),
+                verbose=verbose, parents=True, exist_ok=True
+            )
 
         self.clean_task(verbose=verbose)
         self.fetch_files(verbose=verbose)

--- a/benchcab/fluxsite.py
+++ b/benchcab/fluxsite.py
@@ -132,18 +132,17 @@ class Task:
         if verbose:
             print(f"Setting up task: {self.get_task_name()}")
 
-        with chdir(self.root_dir):
-            mkdir(
-                internal.FLUXSITE_TASKS_DIR / self.get_task_name(),
-                verbose=verbose, parents=True, exist_ok=True
-            )
+        mkdir(
+            internal.FLUXSITE_DIRS["TASKS"] / self.get_task_name(),
+            verbose=verbose, parents=True, exist_ok=True
+        )
 
         self.clean_task(verbose=verbose)
         self.fetch_files(verbose=verbose)
 
         nml_path = (
             self.root_dir
-            / internal.FLUXSITE_TASKS_DIR
+            / internal.FLUXSITE_DIRS["TASKS"]
             / self.get_task_name()
             / internal.CABLE_NML
         )
@@ -158,12 +157,12 @@ class Task:
                         "met": str(internal.MET_DIR / self.met_forcing_file),
                         "out": str(
                             self.root_dir
-                            / internal.FLUXSITE_OUTPUT_DIR
+                            / internal.FLUXSITE_DIRS["OUTPUT"]
                             / self.get_output_filename()
                         ),
                         "log": str(
                             self.root_dir
-                            / internal.FLUXSITE_LOG_DIR
+                            / internal.FLUXSITE_DIRS["LOG"]
                             / self.get_log_filename()
                         ),
                         "restart_out": " ",
@@ -205,7 +204,7 @@ class Task:
         if verbose:
             print("  Cleaning task")
 
-        task_dir = self.root_dir / internal.FLUXSITE_TASKS_DIR / self.get_task_name()
+        task_dir = self.root_dir / internal.FLUXSITE_DIRS["TASKS"] / self.get_task_name()
 
         cable_exe = task_dir / internal.CABLE_EXE
         if cable_exe.exists():
@@ -224,12 +223,12 @@ class Task:
             cable_soil_nml.unlink()
 
         output_file = (
-            self.root_dir / internal.FLUXSITE_OUTPUT_DIR / self.get_output_filename()
+            self.root_dir / internal.FLUXSITE_DIRS["OUTPUT"] / self.get_output_filename()
         )
         if output_file.exists():
             output_file.unlink()
 
-        log_file = self.root_dir / internal.FLUXSITE_LOG_DIR / self.get_log_filename()
+        log_file = self.root_dir / internal.FLUXSITE_DIRS["LOG"] / self.get_log_filename()
         if log_file.exists():
             log_file.unlink()
 
@@ -242,7 +241,7 @@ class Task:
         - copies contents of 'namelists' directory to 'runs/fluxsite/tasks/<task_name>' directory.
         - copies cable executable from source to 'runs/fluxsite/tasks/<task_name>' directory.
         """
-        task_dir = self.root_dir / internal.FLUXSITE_TASKS_DIR / self.get_task_name()
+        task_dir = self.root_dir / internal.FLUXSITE_DIRS["TASKS"] / self.get_task_name()
 
         if verbose:
             print(
@@ -273,7 +272,7 @@ class Task:
     def run(self, verbose=False):
         """Runs a single fluxsite task."""
         task_name = self.get_task_name()
-        task_dir = self.root_dir / internal.FLUXSITE_TASKS_DIR / task_name
+        task_dir = self.root_dir / internal.FLUXSITE_DIRS["TASKS"] / task_name
         if verbose:
             print(
                 f"Running task {task_name}... CABLE standard output "
@@ -291,7 +290,7 @@ class Task:
         Raises `CableError` when CABLE returns a non-zero exit code.
         """
         task_name = self.get_task_name()
-        task_dir = self.root_dir / internal.FLUXSITE_TASKS_DIR / task_name
+        task_dir = self.root_dir / internal.FLUXSITE_DIRS["TASKS"] / task_name
         stdout_path = task_dir / internal.CABLE_STDOUT_FILENAME
 
         try:
@@ -312,11 +311,11 @@ class Task:
         the namelist file used to run cable.
         """
         nc_output_path = (
-            self.root_dir / internal.FLUXSITE_OUTPUT_DIR / self.get_output_filename()
+            self.root_dir / internal.FLUXSITE_DIRS["OUTPUT"] / self.get_output_filename()
         )
         nml = f90nml.read(
             self.root_dir
-            / internal.FLUXSITE_TASKS_DIR
+            / internal.FLUXSITE_DIRS["TASKS"]
             / self.get_task_name()
             / internal.CABLE_NML
         )
@@ -403,7 +402,7 @@ def get_fluxsite_comparisons(
     forcing, but differ in realisations. When multiple realisations are
     specified, return all pair wise combinations between all realisations.
     """
-    output_dir = root_dir / internal.FLUXSITE_OUTPUT_DIR
+    output_dir = root_dir / internal.FLUXSITE_DIRS["OUTPUT"]
     return [
         ComparisonTask(
             files=(

--- a/benchcab/internal.py
+++ b/benchcab/internal.py
@@ -57,23 +57,27 @@ CNPBIOME_FILE = (
     CABLE_AUX_DIR / "core" / "biogeochem" / "pftlookup_csiro_v16_17tiles.csv"
 )
 
+# Fluxsite directory tree
+FLUXSITE_DIRS = {}
 # Relative path to root directory for CABLE fluxsite runs
-FLUXSITE_RUN_DIR = RUN_DIR / "fluxsite"
+FLUXSITE_DIRS["RUN"] = RUN_DIR / "fluxsite"
 
 # Relative path to directory that stores CABLE log files
-FLUXSITE_LOG_DIR = FLUXSITE_RUN_DIR / "logs"
+FLUXSITE_DIRS["LOG"] = FLUXSITE_DIRS["RUN"] / "logs"
 
 # Relative path to directory that stores CABLE output files
-FLUXSITE_OUTPUT_DIR = FLUXSITE_RUN_DIR / "outputs"
+FLUXSITE_DIRS["OUTPUT"] = FLUXSITE_DIRS["RUN"] / "outputs"
 
 # Relative path to tasks directory where cable executables are run from
-FLUXSITE_TASKS_DIR = FLUXSITE_RUN_DIR / "tasks"
+FLUXSITE_DIRS["TASKS"] = FLUXSITE_DIRS["RUN"] / "tasks"
 
 # Relative path to directory that stores results of analysis on model output
-FLUXSITE_ANALYSIS_DIR = FLUXSITE_RUN_DIR / "analysis"
+FLUXSITE_DIRS["ANALYSIS"] = FLUXSITE_DIRS["RUN"] / "analysis"
 
 # Relative path to directory that stores bitwise comparison results
-FLUXSITE_BITWISE_CMP_DIR = FLUXSITE_ANALYSIS_DIR / "bitwise-comparisons"
+FLUXSITE_DIRS["BITWISE_CMP"] = (
+    FLUXSITE_DIRS["ANALYSIS"] / "bitwise-comparisons"
+)
 
 # Path to met files:
 MET_DIR = Path("/g/data/ks32/CLEX_Data/PLUMBER2/v1-0/Met/")

--- a/benchcab/utils/fs.py
+++ b/benchcab/utils/fs.py
@@ -52,3 +52,21 @@ def next_path(path: Path, path_pattern: str, sep: str = "-"):
         new_file_index = int(last_file_index) + 1
 
     return f"{common_filename}{sep}{new_file_index}{loc_pattern.suffix}"
+
+
+def mkdir(new_path: Path, verbose=False, **kwargs):
+    """Create the `new_path` directory.
+
+    Parameters
+    ----------
+    new_path : Path
+        Path to the directory to be created.
+    verbose : bool, default False
+        Additional level of logging if True
+    **kwargs : dict, optional
+        Additional options for `pathlib.Path.mkdir()`
+    """
+
+    if verbose:
+        print(f"Creating {new_path} directory")
+    new_path.mkdir(**kwargs)

--- a/benchcab/workdir.py
+++ b/benchcab/workdir.py
@@ -1,12 +1,11 @@
-"""A module containing functions for generating the directory structure used for `benchcab`."""
+"""A module containing functions for generating the directory structure
+used for `benchcab`."""
 
 from pathlib import Path
-import os
 import shutil
-from typing import Union
 
 from benchcab import internal
-from benchcab.fluxsite import Task
+from benchcab.utils.fs import mkdir, chdir
 
 
 def clean_directory_tree(root_dir=internal.CWD):
@@ -20,68 +19,33 @@ def clean_directory_tree(root_dir=internal.CWD):
         shutil.rmtree(run_dir)
 
 
-def setup_src_dir(root_dir=internal.CWD):
-    """Make `src` directory."""
+def setup_fluxsite_directory_tree(root_dir=internal.CWD, verbose=False):
+    """Generate the directory structure used by `benchcab`.
 
-    src_dir = Path(root_dir, internal.SRC_DIR)
-    if not src_dir.exists():
-        print(f"Creating {src_dir.relative_to(root_dir)} directory: {src_dir}")
-        os.makedirs(src_dir)
+    Parameters
+    ----------
+    root_dir : Path, optional
+        The root directory to add to relative paths, by default internal.CWD
+    verbose : bool, default False
+        Additional level of logging if True
+    """
 
+    # Create the list of directories.
+    fluxsite_paths = [
+        # Fluxsite run directory
+        internal.FLUXSITE_RUN_DIR,
+        # Fluxsite log directory
+        internal.FLUXSITE_LOG_DIR,
+        # Fluxsite output directory
+        internal.FLUXSITE_OUTPUT_DIR,
+        # Fluxsite tasks directory
+        internal.FLUXSITE_TASKS_DIR,
+        # Fluxsite analysis directory
+        internal.FLUXSITE_ANALYSIS_DIR,
+        # Fluxsite bit-wise comparison directory
+        internal.FLUXSITE_BITWISE_CMP_DIR,
+    ]
 
-def fluxsite_directory_tree_list(fluxsite_tasks: list[Task], root_dir=internal.CWD) -> set:
-    """Generate a list of all the work directories used for fluxsite tests"""
-
-    # Create the list of directories as sets because the order is not important
-    # and we want to avoid duplications.
-    fluxsite_paths = []
-
-    # Run directory
-    fluxsite_paths.append(Path(root_dir, internal.RUN_DIR))
-
-    # Fluxsite run directory
-    fluxsite_paths.append(Path(root_dir, internal.FLUXSITE_RUN_DIR))
-
-    # Fluxsite log directory
-    fluxsite_paths.append(Path(root_dir, internal.FLUXSITE_LOG_DIR))
-
-    # Fluxsite output directory
-    fluxsite_paths.append(Path(root_dir, internal.FLUXSITE_OUTPUT_DIR))
-
-    # Fluxsite tasks directory
-    fluxsite_paths.append(Path(root_dir, internal.FLUXSITE_TASKS_DIR))
-
-    # Fluxsite analysis directory
-    fluxsite_paths.append(Path(root_dir, internal.FLUXSITE_ANALYSIS_DIR))
-
-    # Fluxsite bit-wise comparison directory
-    fluxsite_paths.append(Path(root_dir, internal.FLUXSITE_BITWISE_CMP_DIR))
-
-    # Fluxsite tasks directories. append all of them as a set().
-    task_paths = []
-    for task in fluxsite_tasks:
-        task_paths.append(
-            Path(root_dir, internal.FLUXSITE_TASKS_DIR, task.get_task_name()))
-    fluxsite_paths.append(task_paths)
-
-    return fluxsite_paths
-
-
-def setup_fluxsite_directory_tree(
-    fluxsite_paths: list[Union[Path, list]], root_dir=internal.CWD, verbose=False
-):
-    """Generate the directory structure used by `benchcab`."""
-
-    for work_path in fluxsite_paths:
-        if isinstance(work_path, list):
-            print("Creating task directories...")
-
-            for task_dir in work_path:
-                if verbose:
-                    print(f"Creating {task_dir.relative_to(root_dir)}: {task_dir}")
-                task_dir.mkdir(parents=True, exist_ok=True)
-        else:
-            print(
-                f"Creating {work_path.relative_to(root_dir)} directory: {work_path}"
-            )
-            work_path.mkdir(parents=True, exist_ok=True)
+    with chdir(root_dir):
+        for path in fluxsite_paths:
+            mkdir(path, verbose=verbose, parents=True, exist_ok=True)

--- a/benchcab/workdir.py
+++ b/benchcab/workdir.py
@@ -1,5 +1,4 @@
-"""A module containing functions for generating the directory structure
-used for `benchcab`."""
+"""Functions for generating the directory structure used for `benchcab`."""
 
 import shutil
 
@@ -24,6 +23,5 @@ def setup_fluxsite_directory_tree(verbose=False):
     verbose : bool, default False
         Additional level of logging if True
     """
-
     for path in internal.FLUXSITE_DIRS.values():
         mkdir(path, verbose=verbose, parents=True, exist_ok=True)

--- a/benchcab/workdir.py
+++ b/benchcab/workdir.py
@@ -2,50 +2,28 @@
 used for `benchcab`."""
 
 import shutil
-from pathlib import Path
 
 from benchcab import internal
-from benchcab.utils.fs import mkdir, chdir
+from benchcab.utils.fs import mkdir
 
 
-def clean_directory_tree(root_dir=internal.CWD):
+def clean_directory_tree():
     """Remove pre-existing directories in current working directory."""
-    src_dir = Path(root_dir, internal.SRC_DIR)
-    if src_dir.exists():
-        shutil.rmtree(src_dir)
+    if internal.SRC_DIR.exists():
+        shutil.rmtree(internal.SRC_DIR)
 
-    run_dir = Path(root_dir, internal.RUN_DIR)
-    if run_dir.exists():
-        shutil.rmtree(run_dir)
+    if internal.RUN_DIR.exists():
+        shutil.rmtree(internal.RUN_DIR)
 
 
-def setup_fluxsite_directory_tree(root_dir=internal.CWD, verbose=False):
+def setup_fluxsite_directory_tree(verbose=False):
     """Generate the directory structure used by `benchcab`.
 
     Parameters
     ----------
-    root_dir : Path, optional
-        The root directory to add to relative paths, by default internal.CWD
     verbose : bool, default False
         Additional level of logging if True
     """
 
-    # Create the list of directories.
-    fluxsite_paths = [
-        # Fluxsite run directory
-        internal.FLUXSITE_RUN_DIR,
-        # Fluxsite log directory
-        internal.FLUXSITE_LOG_DIR,
-        # Fluxsite output directory
-        internal.FLUXSITE_OUTPUT_DIR,
-        # Fluxsite tasks directory
-        internal.FLUXSITE_TASKS_DIR,
-        # Fluxsite analysis directory
-        internal.FLUXSITE_ANALYSIS_DIR,
-        # Fluxsite bit-wise comparison directory
-        internal.FLUXSITE_BITWISE_CMP_DIR,
-    ]
-
-    with chdir(root_dir):
-        for path in fluxsite_paths:
-            mkdir(path, verbose=verbose, parents=True, exist_ok=True)
+    for path in internal.FLUXSITE_DIRS.values():
+        mkdir(path, verbose=verbose, parents=True, exist_ok=True)

--- a/tests/test_benchcab.py
+++ b/tests/test_benchcab.py
@@ -47,11 +47,11 @@ def test_fluxsite_submit_job():
         f"nodes: {internal.QSUB_FNAME}\n"
         f"PBS job submitted: {mock_subprocess.stdout}\n"
         "The CABLE log file for each task is written to "
-        f"{internal.FLUXSITE_LOG_DIR}/<task_name>_log.txt\n"
+        f"{internal.FLUXSITE_DIRS['LOG']}/<task_name>_log.txt\n"
         "The CABLE standard output for each task is written to "
-        f"{internal.FLUXSITE_TASKS_DIR}/<task_name>/out.txt\n"
+        f"{internal.FLUXSITE_DIRS['TASKS']}/<task_name>/out.txt\n"
         "The NetCDF output for each task is written to "
-        f"{internal.FLUXSITE_OUTPUT_DIR}/<task_name>_out.nc\n"
+        f"{internal.FLUXSITE_DIRS['OUTPUT']}/<task_name>_out.nc\n"
     )
 
     # Failure case: qsub non-zero exit code prints an error message

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -27,7 +27,7 @@ def test_run_comparison():
     """Tests for `run_comparison()`."""
     file_a = MOCK_CWD / "file_a.nc"
     file_b = MOCK_CWD / "file_b.nc"
-    bitwise_cmp_dir = MOCK_CWD / internal.FLUXSITE_BITWISE_CMP_DIR
+    bitwise_cmp_dir = MOCK_CWD / internal.FLUXSITE_DIRS["BITWISE_CMP"]
     bitwise_cmp_dir.mkdir(parents=True)
 
     # Success case: run comparison

--- a/tests/test_fluxsite.py
+++ b/tests/test_fluxsite.py
@@ -307,6 +307,7 @@ def test_setup_task():
         task.setup_task(verbose=True)
     assert buf.getvalue() == (
         "Setting up task: forcing-file_R1_S0\n"
+        "Creating runs/fluxsite/tasks/forcing-file_R1_S0 directory\n"
         "  Cleaning task\n"
         f"  Copying namelist files from {MOCK_CWD}/namelists to "
         f"{MOCK_CWD / 'runs/fluxsite/tasks/forcing-file_R1_S0'}\n"

--- a/tests/test_fluxsite.py
+++ b/tests/test_fluxsite.py
@@ -70,11 +70,11 @@ def setup_mock_namelists_directory():
 
 def setup_mock_run_directory(task: Task):
     """Setup mock run directory for a single task."""
-    task_dir = MOCK_CWD / internal.FLUXSITE_TASKS_DIR / task.get_task_name()
+    task_dir = MOCK_CWD / internal.FLUXSITE_DIRS["TASKS"] / task.get_task_name()
     task_dir.mkdir(parents=True)
-    output_dir = MOCK_CWD / internal.FLUXSITE_OUTPUT_DIR
+    output_dir = MOCK_CWD / internal.FLUXSITE_DIRS["OUTPUT"]
     output_dir.mkdir(parents=True)
-    log_dir = MOCK_CWD / internal.FLUXSITE_LOG_DIR
+    log_dir = MOCK_CWD / internal.FLUXSITE_DIRS["LOG"]
     log_dir.mkdir(parents=True)
 
 
@@ -92,12 +92,12 @@ def do_mock_checkout_and_build():
 def do_mock_run(task: Task):
     """Make mock log files and output files as if benchcab has just been run."""
     output_path = Path(
-        MOCK_CWD, internal.FLUXSITE_OUTPUT_DIR, task.get_output_filename()
+        MOCK_CWD, internal.FLUXSITE_DIRS["OUTPUT"], task.get_output_filename()
     )
     output_path.touch()
     assert output_path.exists()
 
-    log_path = Path(MOCK_CWD, internal.FLUXSITE_LOG_DIR, task.get_log_filename())
+    log_path = Path(MOCK_CWD, internal.FLUXSITE_DIRS["LOG"], task.get_log_filename())
     log_path.touch()
     assert log_path.exists()
 
@@ -135,22 +135,22 @@ def test_fetch_files():
     task.fetch_files()
 
     assert Path(
-        MOCK_CWD, internal.FLUXSITE_TASKS_DIR, task.get_task_name(), internal.CABLE_NML
+        MOCK_CWD, internal.FLUXSITE_DIRS["TASKS"], task.get_task_name(), internal.CABLE_NML
     ).exists()
     assert Path(
         MOCK_CWD,
-        internal.FLUXSITE_TASKS_DIR,
+        internal.FLUXSITE_DIRS["TASKS"],
         task.get_task_name(),
         internal.CABLE_VEGETATION_NML,
     ).exists()
     assert Path(
         MOCK_CWD,
-        internal.FLUXSITE_TASKS_DIR,
+        internal.FLUXSITE_DIRS["TASKS"],
         task.get_task_name(),
         internal.CABLE_SOIL_NML,
     ).exists()
     assert Path(
-        MOCK_CWD, internal.FLUXSITE_TASKS_DIR, task.get_task_name(), internal.CABLE_EXE
+        MOCK_CWD, internal.FLUXSITE_DIRS["TASKS"], task.get_task_name(), internal.CABLE_EXE
     ).exists()
 
 
@@ -170,28 +170,28 @@ def test_clean_task():
     task.clean_task()
 
     assert not Path(
-        MOCK_CWD, internal.FLUXSITE_TASKS_DIR, task.get_task_name(), internal.CABLE_NML
+        MOCK_CWD, internal.FLUXSITE_DIRS["TASKS"], task.get_task_name(), internal.CABLE_NML
     ).exists()
     assert not Path(
         MOCK_CWD,
-        internal.FLUXSITE_TASKS_DIR,
+        internal.FLUXSITE_DIRS["TASKS"],
         task.get_task_name(),
         internal.CABLE_VEGETATION_NML,
     ).exists()
     assert not Path(
         MOCK_CWD,
-        internal.FLUXSITE_TASKS_DIR,
+        internal.FLUXSITE_DIRS["TASKS"],
         task.get_task_name(),
         internal.CABLE_SOIL_NML,
     ).exists()
     assert not Path(
-        MOCK_CWD, internal.FLUXSITE_TASKS_DIR, task.get_task_name(), internal.CABLE_EXE
+        MOCK_CWD, internal.FLUXSITE_DIRS["TASKS"], task.get_task_name(), internal.CABLE_EXE
     ).exists()
     assert not Path(
-        MOCK_CWD, internal.FLUXSITE_OUTPUT_DIR, task.get_output_filename()
+        MOCK_CWD, internal.FLUXSITE_DIRS["OUTPUT"], task.get_output_filename()
     ).exists()
     assert not Path(
-        MOCK_CWD, internal.FLUXSITE_LOG_DIR, task.get_log_filename()
+        MOCK_CWD, internal.FLUXSITE_DIRS["LOG"], task.get_log_filename()
     ).exists()
 
 
@@ -264,7 +264,7 @@ def test_patch_remove_namelist():
 def test_setup_task():
     """Tests for `setup_task()`."""
     task = get_mock_task()
-    task_dir = Path(MOCK_CWD, internal.FLUXSITE_TASKS_DIR, task.get_task_name())
+    task_dir = Path(MOCK_CWD, internal.FLUXSITE_DIRS["TASKS"], task.get_task_name())
 
     setup_mock_namelists_directory()
     setup_mock_run_directory(task)
@@ -277,9 +277,9 @@ def test_setup_task():
         "filename": {
             "met": str(internal.MET_DIR / "forcing-file.nc"),
             "out": str(
-                MOCK_CWD / internal.FLUXSITE_OUTPUT_DIR / task.get_output_filename()
+                MOCK_CWD / internal.FLUXSITE_DIRS["OUTPUT"] / task.get_output_filename()
             ),
-            "log": str(MOCK_CWD / internal.FLUXSITE_LOG_DIR / task.get_log_filename()),
+            "log": str(MOCK_CWD / internal.FLUXSITE_DIRS["LOG"] / task.get_log_filename()),
             "restart_out": " ",
             "type": str(MOCK_CWD / internal.GRID_FILE),
         },
@@ -323,7 +323,7 @@ def test_run_cable():
     """Tests for `run_cable()`."""
     mock_subprocess = MockSubprocessWrapper()
     task = get_mock_task(subprocess_handler=mock_subprocess)
-    task_dir = MOCK_CWD / internal.FLUXSITE_TASKS_DIR / task.get_task_name()
+    task_dir = MOCK_CWD / internal.FLUXSITE_DIRS["TASKS"] / task.get_task_name()
     task_dir.mkdir(parents=True)
 
     # Success case: run CABLE executable in subprocess
@@ -352,10 +352,10 @@ def test_add_provenance_info():
     """Tests for `add_provenance_info()`."""
     mock_subprocess = MockSubprocessWrapper()
     task = get_mock_task(subprocess_handler=mock_subprocess)
-    task_dir = MOCK_CWD / internal.FLUXSITE_TASKS_DIR / task.get_task_name()
+    task_dir = MOCK_CWD / internal.FLUXSITE_DIRS["TASKS"] / task.get_task_name()
     task_dir.mkdir(parents=True)
-    fluxsite_output_dir = MOCK_CWD / internal.FLUXSITE_OUTPUT_DIR
-    fluxsite_output_dir.mkdir()
+    FLUXSITE_OUTPUT_DIR = MOCK_CWD / internal.FLUXSITE_DIRS["OUTPUT"]
+    FLUXSITE_OUTPUT_DIR.mkdir()
 
     # Create mock namelist file in task directory:
     mock_namelist = {
@@ -364,7 +364,7 @@ def test_add_provenance_info():
     f90nml.write(mock_namelist, task_dir / internal.CABLE_NML)
 
     # Create mock netcdf output file as if CABLE had just been run:
-    nc_output_path = fluxsite_output_dir / task.get_output_filename()
+    nc_output_path = FLUXSITE_OUTPUT_DIR / task.get_output_filename()
     netCDF4.Dataset(nc_output_path, "w")
 
     # Success case: add global attributes to netcdf file
@@ -422,7 +422,7 @@ def test_get_fluxsite_tasks():
 
 def test_get_fluxsite_comparisons():
     """Tests for `get_fluxsite_comparisons()`."""
-    output_dir = MOCK_CWD / internal.FLUXSITE_OUTPUT_DIR
+    output_dir = MOCK_CWD / internal.FLUXSITE_DIRS["OUTPUT"]
 
     # Success case: comparisons for two branches with two tasks
     # met0_S0_R0 met0_S0_R1

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -1,6 +1,11 @@
 """`pytest` tests for utils/fs.py"""
 
-from benchcab.utils.fs import next_path
+import pytest
+import io
+import contextlib
+from pathlib import Path
+
+from benchcab.utils.fs import next_path, mkdir
 from .common import MOCK_CWD
 
 
@@ -20,3 +25,30 @@ def test_next_path():
     assert len(list(MOCK_CWD.glob(pattern))) == 1
     ret = next_path(MOCK_CWD, pattern)
     assert ret == "rev_number-2.log"
+
+
+@pytest.mark.parametrize("test_path,kwargs", [
+    (Path(MOCK_CWD, "test1"), {}),
+    (Path(MOCK_CWD, "test1/test2"), dict(parents=True)),
+    (Path(MOCK_CWD, "test1/test2"), dict(parents=True, exist_ok=True)),
+])
+def test_mkdir(test_path, kwargs):
+    """Tests for `mkdir()`."""
+
+    # Success case: create a test directory
+    mkdir(test_path, **kwargs)
+    assert test_path.exists()
+    test_path.rmdir()
+
+
+def test_mkdir_verbose():
+    """Tests for verbose output of `mkdir()`."""
+
+    # Success case: verbose output
+    test_path = Path(MOCK_CWD, "test1")
+    with contextlib.redirect_stdout(io.StringIO()) as buf:
+        mkdir(test_path, verbose=True)
+    assert buf.getvalue() == (
+        f"Creating {test_path} directory\n"
+    )
+    test_path.rmdir()

--- a/tests/test_workdir.py
+++ b/tests/test_workdir.py
@@ -1,11 +1,9 @@
 """`pytest` tests for `workdir.py`."""
 
-import shutil
 from pathlib import Path
 
 import pytest
 
-from benchcab.utils.fs import mkdir
 from benchcab.workdir import (
     clean_directory_tree,
     setup_fluxsite_directory_tree,
@@ -34,13 +32,11 @@ def test_setup_directory_tree():
     for path in setup_mock_fluxsite_directory_list():
         assert path.exists()
 
-    shutil.rmtree(Path("runs"))
-
 
 @pytest.mark.parametrize("test_path", [Path("runs"), Path("src")])
 def test_clean_directory_tree(test_path):
     """Tests for `clean_directory_tree()`."""
     # Success case: directory tree does not exist after clean
-    mkdir(test_path)
+    test_path.mkdir()
     clean_directory_tree()
     assert not test_path.exists()

--- a/tests/test_workdir.py
+++ b/tests/test_workdir.py
@@ -1,154 +1,53 @@
 """`pytest` tests for workdir.py"""
 
-import io
-import contextlib
 import shutil
 from pathlib import Path
 
 
 from tests.common import MOCK_CWD
-from tests.common import get_mock_config
-from benchcab.fluxsite import Task
-from benchcab.repository import CableRepository
 from benchcab.workdir import (
-    fluxsite_directory_tree_list,
     setup_fluxsite_directory_tree,
     clean_directory_tree,
-    setup_src_dir,
 )
+from benchcab.utils.fs import mkdir
 
 
-def setup_mock_tasks() -> list[Task]:
-    """Return a mock list of fluxsite tasks."""
+def setup_mock_fluxsite_directory_list():
+    """Return the list of work directories we want benchcab to create"""
 
-    config = get_mock_config()
-    repo_a = CableRepository("trunk", repo_id=0)
-    repo_b = CableRepository("path/to/my-branch", repo_id=1)
-    met_forcing_file_a, met_forcing_file_b = "site_foo", "site_bar"
-    (sci_id_a, sci_config_a), (sci_id_b, sci_config_b) = enumerate(
-        config["science_configurations"]
-    )
-
-    tasks = [
-        Task(repo_a, met_forcing_file_a, sci_id_a, sci_config_a),
-        Task(repo_a, met_forcing_file_a, sci_id_b, sci_config_b),
-        Task(repo_a, met_forcing_file_b, sci_id_a, sci_config_a),
-        Task(repo_a, met_forcing_file_b, sci_id_b, sci_config_b),
-        Task(repo_b, met_forcing_file_a, sci_id_a, sci_config_a),
-        Task(repo_b, met_forcing_file_a, sci_id_b, sci_config_b),
-        Task(repo_b, met_forcing_file_b, sci_id_a, sci_config_a),
-        Task(repo_b, met_forcing_file_b, sci_id_b, sci_config_b),
+    fluxsite_directory_list = [
+        Path(MOCK_CWD, "runs", "fluxsite"),
+        Path(MOCK_CWD, "runs", "fluxsite", "logs"),
+        Path(MOCK_CWD, "runs", "fluxsite", "outputs"),
+        Path(MOCK_CWD, "runs", "fluxsite", "tasks"),
+        Path(MOCK_CWD, "runs", "fluxsite", "analysis"),
+        Path(MOCK_CWD, "runs", "fluxsite", "analysis", "bitwise-comparisons"),
     ]
 
-    return tasks
-
-
-def setup_mock_directory_tree_list():
-    """Return the list of directories for the work directory we want benchcab to create"""
-
-    full_directory_lists = []
-    full_directory_lists.append(Path(MOCK_CWD, "runs"))
-    full_directory_lists.append(Path(MOCK_CWD, "runs", "fluxsite"))
-    full_directory_lists.append(Path(MOCK_CWD, "runs", "fluxsite", "logs"))
-    full_directory_lists.append(Path(MOCK_CWD, "runs", "fluxsite", "outputs"))
-    full_directory_lists.append(Path(MOCK_CWD, "runs", "fluxsite", "tasks"))
-    full_directory_lists.append(Path(MOCK_CWD, "runs", "fluxsite", "analysis"))
-    full_directory_lists.append(Path(MOCK_CWD, "runs", "fluxsite",
-                                "analysis", "bitwise-comparisons"))
-
-    task_directories = []
-    task_directories.append(Path(MOCK_CWD, "runs", "fluxsite", "tasks", "site_foo_R0_S0"))
-    task_directories.append(Path(MOCK_CWD, "runs", "fluxsite", "tasks", "site_foo_R0_S1"))
-    task_directories.append(Path(MOCK_CWD, "runs", "fluxsite", "tasks", "site_bar_R0_S0"))
-    task_directories.append(Path(MOCK_CWD, "runs", "fluxsite", "tasks", "site_bar_R0_S1"))
-    task_directories.append(Path(MOCK_CWD, "runs", "fluxsite", "tasks", "site_foo_R1_S0"))
-    task_directories.append(Path(MOCK_CWD, "runs", "fluxsite", "tasks", "site_foo_R1_S1"))
-    task_directories.append(Path(MOCK_CWD, "runs", "fluxsite", "tasks", "site_bar_R1_S0"))
-    task_directories.append(Path(MOCK_CWD, "runs", "fluxsite", "tasks", "site_bar_R1_S1"))
-    full_directory_lists.append(task_directories)
-
-    return full_directory_lists
-
-
-def test_fluxsite_directory_tree_list():
-    """Tests for `fluxsite_directory_tree_list()`."""
-
-    # Success case: generate the full lists of directories for the mock tasks
-    tasks = setup_mock_tasks()
-    full_directory_lists = setup_mock_directory_tree_list()
-
-    fluxsite_paths = fluxsite_directory_tree_list(
-        fluxsite_tasks=tasks, root_dir=MOCK_CWD)
-
-    assert fluxsite_paths == full_directory_lists
+    return fluxsite_directory_list
 
 
 def test_setup_directory_tree():
     """Tests for `setup_fluxsite_directory_tree()`."""
 
-    mock_directory_list = [Path(MOCK_CWD, "test"), Path(MOCK_CWD, "test", "test1"), [
-        Path(MOCK_CWD, "test", "task1"), Path(MOCK_CWD, "test", "task2")]]
+    # Success case: generate the full fluxsite directory structure
+    setup_fluxsite_directory_tree(root_dir=MOCK_CWD, verbose=True)
 
-    # Success case: generate given directory structure
-    tasks = setup_mock_tasks()
-    setup_fluxsite_directory_tree(mock_directory_list, root_dir=MOCK_CWD)
+    for path in setup_mock_fluxsite_directory_list():
+        assert path.exists()
 
-    assert Path(MOCK_CWD, "test").exists()
-    assert Path(MOCK_CWD, "test", "test1").exists()
-    assert Path(MOCK_CWD, "test", "task1").exists()
-    assert Path(MOCK_CWD, "test", "task2").exists()
-
-    shutil.rmtree(MOCK_CWD / "test")
-
-    # Success case: test non-verbose output
-    with contextlib.redirect_stdout(io.StringIO()) as buf:
-        setup_fluxsite_directory_tree(mock_directory_list, root_dir=MOCK_CWD)
-    assert buf.getvalue() == (
-        f"Creating test directory: {MOCK_CWD}/test\n"
-        f"Creating test/test1 directory: {MOCK_CWD}/test/test1\n"
-        f"Creating task directories...\n"
-    )
-
-    shutil.rmtree(MOCK_CWD / "test")
-
-    # Success case: test verbose output
-    with contextlib.redirect_stdout(io.StringIO()) as buf:
-        setup_fluxsite_directory_tree(
-            mock_directory_list, verbose=True, root_dir=MOCK_CWD
-        )
-    assert buf.getvalue() == (
-        f"Creating test directory: {MOCK_CWD}/test\n"
-        f"Creating test/test1 directory: {MOCK_CWD}/test/test1\n"
-        f"Creating task directories...\n"
-        f"Creating test/task1: "
-        f"{MOCK_CWD}/test/task1\n"
-        f"Creating test/task2: "
-        f"{MOCK_CWD}/test/task2\n"
-    )
-
-    shutil.rmtree(MOCK_CWD / "test")
+    shutil.rmtree(Path(MOCK_CWD, "runs"))
 
 
 def test_clean_directory_tree():
     """Tests for `clean_directory_tree()`."""
 
     # Success case: directory tree does not exist after clean
-    tasks = setup_mock_tasks()
-    full_directory_lists = setup_mock_directory_tree_list()
-
-    setup_fluxsite_directory_tree(full_directory_lists, root_dir=MOCK_CWD)
+    setup_fluxsite_directory_tree(root_dir=MOCK_CWD)
 
     clean_directory_tree(root_dir=MOCK_CWD)
     assert not Path(MOCK_CWD, "runs").exists()
 
-    setup_src_dir(root_dir=MOCK_CWD)
+    mkdir(Path(MOCK_CWD, "src"), exist_ok=True)
     clean_directory_tree(root_dir=MOCK_CWD)
     assert not Path(MOCK_CWD, "src").exists()
-
-
-def test_setup_src_dir():
-    """Tests for `setup_src_dir()`."""
-
-    # Success case: make src directory
-    setup_src_dir(root_dir=MOCK_CWD)
-    assert Path(MOCK_CWD, "src").exists()

--- a/tests/test_workdir.py
+++ b/tests/test_workdir.py
@@ -3,7 +3,8 @@
 import shutil
 from pathlib import Path
 
-from benchcab import internal
+import pytest
+
 from benchcab.utils.fs import mkdir
 from benchcab.workdir import (
     clean_directory_tree,
@@ -12,8 +13,7 @@ from benchcab.workdir import (
 
 
 def setup_mock_fluxsite_directory_list():
-    """Return the list of work directories we want benchcab to create"""
-
+    """Return the list of work directories we want benchcab to create."""
     fluxsite_directory_list = [
         Path("runs", "fluxsite"),
         Path("runs", "fluxsite", "logs"),
@@ -28,7 +28,6 @@ def setup_mock_fluxsite_directory_list():
 
 def test_setup_directory_tree():
     """Tests for `setup_fluxsite_directory_tree()`."""
-
     # Success case: generate the full fluxsite directory structure
     setup_fluxsite_directory_tree()
 
@@ -38,18 +37,10 @@ def test_setup_directory_tree():
     shutil.rmtree(Path("runs"))
 
 
-def test_clean_directory_tree():
+@pytest.mark.parametrize("test_path", [Path("runs"), Path("src")])
+def test_clean_directory_tree(test_path):
     """Tests for `clean_directory_tree()`."""
     # Success case: directory tree does not exist after clean
-    mkdir(internal.RUN_DIR)
-    mkdir(internal.SRC_DIR)
+    mkdir(test_path)
     clean_directory_tree()
-    assert not internal.RUN_DIR.exists()
-    assert not internal.SRC_DIR.exists()
-    
-    # Success case: clean_directory_tree returns if directories do not exist
-    # before the call
-    clean_directory_tree()
-    assert not internal.RUN_DIR.exists()
-    assert not internal.SRC_DIR.exists()
-    
+    assert not test_path.exists()

--- a/tests/test_workdir.py
+++ b/tests/test_workdir.py
@@ -3,21 +3,24 @@
 import shutil
 from pathlib import Path
 
+from benchcab import internal
 from benchcab.utils.fs import mkdir
-from benchcab.workdir import clean_directory_tree
-from tests.common import MOCK_CWD
+from benchcab.workdir import (
+    clean_directory_tree,
+    setup_fluxsite_directory_tree,
+)
 
 
 def setup_mock_fluxsite_directory_list():
     """Return the list of work directories we want benchcab to create"""
 
     fluxsite_directory_list = [
-        Path(MOCK_CWD, "runs", "fluxsite"),
-        Path(MOCK_CWD, "runs", "fluxsite", "logs"),
-        Path(MOCK_CWD, "runs", "fluxsite", "outputs"),
-        Path(MOCK_CWD, "runs", "fluxsite", "tasks"),
-        Path(MOCK_CWD, "runs", "fluxsite", "analysis"),
-        Path(MOCK_CWD, "runs", "fluxsite", "analysis", "bitwise-comparisons"),
+        Path("runs", "fluxsite"),
+        Path("runs", "fluxsite", "logs"),
+        Path("runs", "fluxsite", "outputs"),
+        Path("runs", "fluxsite", "tasks"),
+        Path("runs", "fluxsite", "analysis"),
+        Path("runs", "fluxsite", "analysis", "bitwise-comparisons"),
     ]
 
     return fluxsite_directory_list
@@ -27,22 +30,26 @@ def test_setup_directory_tree():
     """Tests for `setup_fluxsite_directory_tree()`."""
 
     # Success case: generate the full fluxsite directory structure
-    setup_fluxsite_directory_tree(root_dir=MOCK_CWD, verbose=True)
+    setup_fluxsite_directory_tree()
 
     for path in setup_mock_fluxsite_directory_list():
         assert path.exists()
 
-    shutil.rmtree(Path(MOCK_CWD, "runs"))
+    shutil.rmtree(Path("runs"))
 
 
 def test_clean_directory_tree():
     """Tests for `clean_directory_tree()`."""
     # Success case: directory tree does not exist after clean
-    setup_fluxsite_directory_tree(root_dir=MOCK_CWD)
-
-    clean_directory_tree(root_dir=MOCK_CWD)
-    assert not Path(MOCK_CWD, "runs").exists()
-
-    mkdir(Path(MOCK_CWD, "src"), exist_ok=True)
-    clean_directory_tree(root_dir=MOCK_CWD)
-    assert not Path(MOCK_CWD, "src").exists()
+    mkdir(internal.RUN_DIR)
+    mkdir(internal.SRC_DIR)
+    clean_directory_tree()
+    assert not internal.RUN_DIR.exists()
+    assert not internal.SRC_DIR.exists()
+    
+    # Success case: clean_directory_tree returns if directories do not exist
+    # before the call
+    clean_directory_tree()
+    assert not internal.RUN_DIR.exists()
+    assert not internal.SRC_DIR.exists()
+    

--- a/tests/test_workdir.py
+++ b/tests/test_workdir.py
@@ -11,6 +11,7 @@ from tests.common import get_mock_config
 from benchcab.fluxsite import Task
 from benchcab.repository import CableRepository
 from benchcab.workdir import (
+    fluxsite_directory_tree_list,
     setup_fluxsite_directory_tree,
     clean_directory_tree,
     setup_src_dir,
@@ -42,81 +43,90 @@ def setup_mock_tasks() -> list[Task]:
     return tasks
 
 
+def setup_mock_directory_tree_list():
+    """Return the list of directories for the work directory we want benchcab to create"""
+
+    full_directory_lists = []
+    full_directory_lists.append(Path(MOCK_CWD, "runs"))
+    full_directory_lists.append(Path(MOCK_CWD, "runs", "fluxsite"))
+    full_directory_lists.append(Path(MOCK_CWD, "runs", "fluxsite", "logs"))
+    full_directory_lists.append(Path(MOCK_CWD, "runs", "fluxsite", "outputs"))
+    full_directory_lists.append(Path(MOCK_CWD, "runs", "fluxsite", "tasks"))
+    full_directory_lists.append(Path(MOCK_CWD, "runs", "fluxsite", "analysis"))
+    full_directory_lists.append(Path(MOCK_CWD, "runs", "fluxsite",
+                                "analysis", "bitwise-comparisons"))
+
+    task_directories = []
+    task_directories.append(Path(MOCK_CWD, "runs", "fluxsite", "tasks", "site_foo_R0_S0"))
+    task_directories.append(Path(MOCK_CWD, "runs", "fluxsite", "tasks", "site_foo_R0_S1"))
+    task_directories.append(Path(MOCK_CWD, "runs", "fluxsite", "tasks", "site_bar_R0_S0"))
+    task_directories.append(Path(MOCK_CWD, "runs", "fluxsite", "tasks", "site_bar_R0_S1"))
+    task_directories.append(Path(MOCK_CWD, "runs", "fluxsite", "tasks", "site_foo_R1_S0"))
+    task_directories.append(Path(MOCK_CWD, "runs", "fluxsite", "tasks", "site_foo_R1_S1"))
+    task_directories.append(Path(MOCK_CWD, "runs", "fluxsite", "tasks", "site_bar_R1_S0"))
+    task_directories.append(Path(MOCK_CWD, "runs", "fluxsite", "tasks", "site_bar_R1_S1"))
+    full_directory_lists.append(task_directories)
+
+    return full_directory_lists
+
+
+def test_fluxsite_directory_tree_list():
+    """Tests for `fluxsite_directory_tree_list()`."""
+
+    # Success case: generate the full lists of directories for the mock tasks
+    tasks = setup_mock_tasks()
+    full_directory_lists = setup_mock_directory_tree_list()
+
+    fluxsite_paths = fluxsite_directory_tree_list(
+        fluxsite_tasks=tasks, root_dir=MOCK_CWD)
+
+    assert fluxsite_paths == full_directory_lists
+
+
 def test_setup_directory_tree():
     """Tests for `setup_fluxsite_directory_tree()`."""
 
-    # Success case: generate fluxsite directory structure
+    mock_directory_list = [Path(MOCK_CWD, "test"), Path(MOCK_CWD, "test", "test1"), [
+        Path(MOCK_CWD, "test", "task1"), Path(MOCK_CWD, "test", "task2")]]
+
+    # Success case: generate given directory structure
     tasks = setup_mock_tasks()
-    setup_fluxsite_directory_tree(fluxsite_tasks=tasks, root_dir=MOCK_CWD)
+    setup_fluxsite_directory_tree(mock_directory_list, root_dir=MOCK_CWD)
 
-    assert len(list(MOCK_CWD.glob("*"))) == 1
-    assert Path(MOCK_CWD, "runs").exists()
-    assert Path(MOCK_CWD, "runs", "fluxsite").exists()
-    assert Path(MOCK_CWD, "runs", "fluxsite", "logs").exists()
-    assert Path(MOCK_CWD, "runs", "fluxsite", "outputs").exists()
-    assert Path(MOCK_CWD, "runs", "fluxsite", "tasks").exists()
-    assert Path(
-        MOCK_CWD, "runs", "fluxsite", "analysis", "bitwise-comparisons"
-    ).exists()
+    assert Path(MOCK_CWD, "test").exists()
+    assert Path(MOCK_CWD, "test", "test1").exists()
+    assert Path(MOCK_CWD, "test", "task1").exists()
+    assert Path(MOCK_CWD, "test", "task2").exists()
 
-    assert Path(MOCK_CWD, "runs", "fluxsite", "tasks", "site_foo_R0_S0").exists()
-    assert Path(MOCK_CWD, "runs", "fluxsite", "tasks", "site_foo_R0_S1").exists()
-    assert Path(MOCK_CWD, "runs", "fluxsite", "tasks", "site_bar_R0_S0").exists()
-    assert Path(MOCK_CWD, "runs", "fluxsite", "tasks", "site_bar_R0_S1").exists()
-    assert Path(MOCK_CWD, "runs", "fluxsite", "tasks", "site_foo_R1_S0").exists()
-    assert Path(MOCK_CWD, "runs", "fluxsite", "tasks", "site_foo_R1_S1").exists()
-    assert Path(MOCK_CWD, "runs", "fluxsite", "tasks", "site_bar_R1_S0").exists()
-    assert Path(MOCK_CWD, "runs", "fluxsite", "tasks", "site_bar_R1_S1").exists()
-
-    shutil.rmtree(MOCK_CWD / "runs")
+    shutil.rmtree(MOCK_CWD / "test")
 
     # Success case: test non-verbose output
     with contextlib.redirect_stdout(io.StringIO()) as buf:
-        setup_fluxsite_directory_tree(fluxsite_tasks=tasks, root_dir=MOCK_CWD)
+        setup_fluxsite_directory_tree(mock_directory_list, root_dir=MOCK_CWD)
     assert buf.getvalue() == (
-        f"Creating runs/fluxsite/logs directory: {MOCK_CWD}/runs/fluxsite/logs\n"
-        f"Creating runs/fluxsite/outputs directory: {MOCK_CWD}/runs/fluxsite/outputs\n"
-        f"Creating runs/fluxsite/tasks directory: {MOCK_CWD}/runs/fluxsite/tasks\n"
-        f"Creating runs/fluxsite/analysis directory: {MOCK_CWD}/runs/fluxsite/analysis\n"
-        f"Creating runs/fluxsite/analysis/bitwise-comparisons directory: {MOCK_CWD}"
-        "/runs/fluxsite/analysis/bitwise-comparisons\n"
+        f"Creating test directory: {MOCK_CWD}/test\n"
+        f"Creating test/test1 directory: {MOCK_CWD}/test/test1\n"
         f"Creating task directories...\n"
     )
 
-    shutil.rmtree(MOCK_CWD / "runs")
+    shutil.rmtree(MOCK_CWD / "test")
 
     # Success case: test verbose output
     with contextlib.redirect_stdout(io.StringIO()) as buf:
         setup_fluxsite_directory_tree(
-            fluxsite_tasks=tasks, verbose=True, root_dir=MOCK_CWD
+            mock_directory_list, verbose=True, root_dir=MOCK_CWD
         )
     assert buf.getvalue() == (
-        f"Creating runs/fluxsite/logs directory: {MOCK_CWD}/runs/fluxsite/logs\n"
-        f"Creating runs/fluxsite/outputs directory: {MOCK_CWD}/runs/fluxsite/outputs\n"
-        f"Creating runs/fluxsite/tasks directory: {MOCK_CWD}/runs/fluxsite/tasks\n"
-        f"Creating runs/fluxsite/analysis directory: {MOCK_CWD}/runs/fluxsite/analysis\n"
-        f"Creating runs/fluxsite/analysis/bitwise-comparisons directory: {MOCK_CWD}"
-        "/runs/fluxsite/analysis/bitwise-comparisons\n"
+        f"Creating test directory: {MOCK_CWD}/test\n"
+        f"Creating test/test1 directory: {MOCK_CWD}/test/test1\n"
         f"Creating task directories...\n"
-        f"Creating runs/fluxsite/tasks/site_foo_R0_S0: "
-        f"{MOCK_CWD}/runs/fluxsite/tasks/site_foo_R0_S0\n"
-        f"Creating runs/fluxsite/tasks/site_foo_R0_S1: "
-        f"{MOCK_CWD}/runs/fluxsite/tasks/site_foo_R0_S1\n"
-        f"Creating runs/fluxsite/tasks/site_bar_R0_S0: "
-        f"{MOCK_CWD}/runs/fluxsite/tasks/site_bar_R0_S0\n"
-        f"Creating runs/fluxsite/tasks/site_bar_R0_S1: "
-        f"{MOCK_CWD}/runs/fluxsite/tasks/site_bar_R0_S1\n"
-        f"Creating runs/fluxsite/tasks/site_foo_R1_S0: "
-        f"{MOCK_CWD}/runs/fluxsite/tasks/site_foo_R1_S0\n"
-        f"Creating runs/fluxsite/tasks/site_foo_R1_S1: "
-        f"{MOCK_CWD}/runs/fluxsite/tasks/site_foo_R1_S1\n"
-        f"Creating runs/fluxsite/tasks/site_bar_R1_S0: "
-        f"{MOCK_CWD}/runs/fluxsite/tasks/site_bar_R1_S0\n"
-        f"Creating runs/fluxsite/tasks/site_bar_R1_S1: "
-        f"{MOCK_CWD}/runs/fluxsite/tasks/site_bar_R1_S1\n"
+        f"Creating test/task1: "
+        f"{MOCK_CWD}/test/task1\n"
+        f"Creating test/task2: "
+        f"{MOCK_CWD}/test/task2\n"
     )
 
-    shutil.rmtree(MOCK_CWD / "runs")
+    shutil.rmtree(MOCK_CWD / "test")
 
 
 def test_clean_directory_tree():
@@ -124,7 +134,9 @@ def test_clean_directory_tree():
 
     # Success case: directory tree does not exist after clean
     tasks = setup_mock_tasks()
-    setup_fluxsite_directory_tree(fluxsite_tasks=tasks, root_dir=MOCK_CWD)
+    full_directory_lists = setup_mock_directory_tree_list()
+
+    setup_fluxsite_directory_tree(full_directory_lists, root_dir=MOCK_CWD)
 
     clean_directory_tree(root_dir=MOCK_CWD)
     assert not Path(MOCK_CWD, "runs").exists()


### PR DESCRIPTION
Fixes #150

Added a `mkdir()` wrapper to use throughout the code:

- `benchcab` to create `src/`, hence removing the `setup_src_dir()` function.
- `fluxsite` to create the task directories within `setup_task()`
- `workdir` to create the fluxsite run directory tree.

Defined `FLUXSITE_DIRS`: a dictionary in `internal.py` that contains all the individual directories for the fluxsite runs.

Change the creation and deletion of fluxsite directory tree and source directory to use relative paths instead of absolute paths.