### PR TITLE
Update usage of `set -ex`

### DIFF
--- a/benchcab/utils/pbs.py
+++ b/benchcab/utils/pbs.py
@@ -45,10 +45,10 @@ def render_job_script(
 #PBS -m e
 #PBS -l storage={'+'.join(storage_flags)}
 
-set -ex
-
 module purge
 {module_load_lines}
+
+set -ev
 
 {benchcab_path} fluxsite-run-tasks --config={config_path} {verbose_flag}
 {'' if skip_bitwise_cmp else f'''

--- a/tests/test_pbs.py
+++ b/tests/test_pbs.py
@@ -26,12 +26,12 @@ class TestRenderJobScript:
 #PBS -m e
 #PBS -l storage=gdata/ks32+gdata/hh5
 
-set -ex
-
 module purge
 module load foo
 module load bar
 module load baz
+
+set -ev
 
 /absolute/path/to/benchcab fluxsite-run-tasks --config=/path/to/config.yaml 
 
@@ -60,12 +60,12 @@ module load baz
 #PBS -m e
 #PBS -l storage=gdata/ks32+gdata/hh5
 
-set -ex
-
 module purge
 module load foo
 module load bar
 module load baz
+
+set -ev
 
 /absolute/path/to/benchcab fluxsite-run-tasks --config=/path/to/config.yaml -v
 
@@ -94,12 +94,12 @@ module load baz
 #PBS -m e
 #PBS -l storage=gdata/ks32+gdata/hh5
 
-set -ex
-
 module purge
 module load foo
 module load bar
 module load baz
+
+set -ev
 
 /absolute/path/to/benchcab fluxsite-run-tasks --config=/path/to/config.yaml 
 
@@ -132,12 +132,12 @@ module load baz
 #PBS -m e
 #PBS -l storage=gdata/ks32+gdata/hh5+gdata/foo
 
-set -ex
-
 module purge
 module load foo
 module load bar
 module load baz
+
+set -ev
 
 /absolute/path/to/benchcab fluxsite-run-tasks --config=/path/to/config.yaml 
 
@@ -165,12 +165,12 @@ module load baz
 #PBS -m e
 #PBS -l storage=gdata/ks32+gdata/hh5
 
-set -ex
-
 module purge
 module load foo
 module load bar
 module load baz
+
+set -ev
 
 /absolute/path/to/benchcab fluxsite-run-tasks --config=/path/to/config.yaml 
 


### PR DESCRIPTION
The PBS job script produces a lot of excessive output from the `module purge` and `module load <module>` commands. This can be fixed easily by enabling the set options after the module commands.

Replace xtrace mode `-x` with verbose mode `-v` as the job script is not complex.

Fixes #174