### PR TITLE
Add getter method for built executable

### DIFF
--- a/benchcab/fluxsite.py
+++ b/benchcab/fluxsite.py
@@ -264,13 +264,7 @@ class Task:
             self.root_dir / internal.NAMELIST_DIR, task_dir, dirs_exist_ok=True
         )
 
-        exe_src = (
-            self.root_dir
-            / internal.SRC_DIR
-            / self.repo.name
-            / "offline"
-            / internal.CABLE_EXE
-        )
+        exe_src = self.repo.get_exe_path()
         exe_dest = task_dir / internal.CABLE_EXE
 
         if verbose:

--- a/benchcab/model.py
+++ b/benchcab/model.py
@@ -76,6 +76,16 @@ class Model:
         )
         return proc.stdout.strip()
 
+    def get_exe_path(self) -> Path:
+        """Return the path to the built executable."""
+        return (
+            self.root_dir
+            / internal.SRC_DIR
+            / self.name
+            / "offline"
+            / internal.CABLE_EXE
+        )
+
     def custom_build(self, modules: list[str], verbose=False):
         """Build CABLE using a custom build script."""
         build_script_path = (

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -46,6 +46,17 @@ class TestRepoID:
             _ = repo.repo_id
 
 
+class TestGetExePath:
+    """Tests for `CableRepository.get_exe_path()`."""
+
+    def test_serial_exe_path(self, repo, mock_cwd):
+        """Success case: get path to serial executable."""
+        assert (
+            repo.get_exe_path()
+            == mock_cwd / internal.SRC_DIR / repo.name / "offline" / internal.CABLE_EXE
+        )
+
+
 class TestCheckout:
     """Tests for `Model.checkout()`."""
 


### PR DESCRIPTION
This change removes any hard coded paths to the built executable that are outside the `CableRepository` class and replaces these with a method that returns the path to the executable. This is done to prepare for the changes in #183 which requires paths to vary accross different `CableRepository` objects.

Fixes #199