### PR TITLE
Add support for checking out GitHub repositories

### DIFF
--- a/.conda/benchcab-dev.yaml
+++ b/.conda/benchcab-dev.yaml
@@ -10,3 +10,4 @@ dependencies:
   - pyyaml
   - flatdict
   - cerberus>=1.3.5
+  - gitpython

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -27,3 +27,4 @@ requirements:
         - f90nml
         - flatdict
         - cerberus >=1.3.5
+        - gitpython

--- a/benchcab/data/config-schema.yml
+++ b/benchcab/data/config-schema.yml
@@ -29,15 +29,36 @@ realisations:
   schema:
     type: "dict"
     schema:
-      path:
-        type: "string"
+      repo:
+        type: "dict"
+        required: true
+        schema:
+          git:
+            type: "dict"
+            excludes: "svn"
+            schema:
+              branch:
+                type: "string"
+                required: true
+              commit:
+                type: "string"
+                required: false
+              url:
+                type: "string"
+                required: false
+          svn:
+            type: "dict"
+            excludes: "git"
+            schema:
+              branch_path:
+                type: "string"
+                required: true
+              revision:
+                type: "integer"
       name:
         type: "string"
         required: false
       build_script:
-        type: "string"
-        required: false
-      revision:
         type: "string"
         required: false
       patch:

--- a/benchcab/data/test/config-valid.yml
+++ b/benchcab/data/test/config-valid.yml
@@ -19,14 +19,13 @@ project: w97
 
 experiment: five-site-test
 
-realisations: [
-  {
-    path: "trunk",
-  },
-  {
-    path: "branches/Users/ccc561/v3.0-YP-changes",
-  }
-]
+realisations:
+  - repo:
+      svn:
+        branch_path: trunk
+  - repo:
+      svn:
+        branch_path: branches/Users/ccc561/v3.0-YP-changes
 
 modules: [
   intel-compiler/2021.1.1,

--- a/benchcab/data/test/integration.sh
+++ b/benchcab/data/test/integration.sh
@@ -20,8 +20,12 @@ project: $PROJECT
 experiment: AU-Tum
 
 realisations:
-  - path: trunk
-  - path: branches/Users/sb8430/test-branch
+  - repo:
+      svn:
+        branch_path: trunk
+  - repo:
+      svn:
+        branch_path: branches/Users/sb8430/test-branch
 
 modules: [
   intel-compiler/2021.1.1,

--- a/benchcab/data/test/integration.sh
+++ b/benchcab/data/test/integration.sh
@@ -24,8 +24,8 @@ realisations:
       svn:
         branch_path: trunk
   - repo:
-      svn:
-        branch_path: branches/Users/sb8430/test-branch
+      git:
+        branch: main
 
 modules: [
   intel-compiler/2021.1.1,

--- a/benchcab/internal.py
+++ b/benchcab/internal.py
@@ -86,6 +86,9 @@ MET_DIR = Path("/g/data/ks32/CLEX_Data/PLUMBER2/v1-0/Met/")
 # CABLE SVN root url:
 CABLE_SVN_ROOT = "https://trac.nci.org.au/svn/cable"
 
+# CABLE GitHub URL:
+CABLE_GIT_URL = "https://github.com/CABLE-LSM/CABLE.git"
+
 # CABLE executable file name:
 CABLE_EXE = "cable-mpi" if MPI else "cable"
 

--- a/benchcab/model.py
+++ b/benchcab/model.py
@@ -40,6 +40,9 @@ class Model:
         self.build_script = build_script
         self._model_id = model_id
         self.src_dir = Path()
+        # TODO(Sean) we should not have to know whether `repo` is a `GitRepo` or
+        # `SVNRepo`, we should only be working with the `Repo` interface.
+        # See issue https://github.com/CABLE-LSM/benchcab/issues/210
         if isinstance(repo, GitRepo):
             self.src_dir = Path("src")
 

--- a/benchcab/utils/repo.py
+++ b/benchcab/utils/repo.py
@@ -1,0 +1,241 @@
+"""Contains classes for handling and abstracting different version control systems."""
+
+from abc import ABC as AbstractBaseClass  # noqa: N811
+from abc import abstractmethod
+from pathlib import Path
+from typing import Optional
+
+import git
+
+from benchcab import internal
+from benchcab.utils.subprocess import SubprocessWrapper, SubprocessWrapperInterface
+
+
+class Repo(AbstractBaseClass):
+    """A general interface for working with code repositories.
+
+    The interface has been designed so that it can be implemented with different
+    version control systems like Git or SVN.
+    """
+
+    @abstractmethod
+    def checkout(self, verbose=False):
+        """Checkout the source code.
+
+        Parameters
+        ----------
+        verbose: bool, optional
+            Enable or disable verbose output. By default `verbose` is `False`.
+        """
+
+    @abstractmethod
+    def get_revision(self) -> str:
+        """Return the latest revision of the source code.
+
+        Returns
+        -------
+        str
+            Human readable string describing the latest revision.
+        """
+
+    @abstractmethod
+    def get_branch_name(self) -> str:
+        """Return the branch name of the source code.
+
+        Returns
+        -------
+        str
+            Branch name of the source code.
+        """
+
+
+class GitRepo(Repo):
+    """A concrete implementation of the `Repo` class using a Git backend.
+
+    Attributes
+    ----------
+    subprocess_handler: SubprocessWrapper
+        Object for handling subprocess calls.
+    """
+
+    subprocess_handler = SubprocessWrapper()
+
+    def __init__(
+        self, url: str, branch: str, path: Path, commit: Optional[str] = None
+    ) -> None:
+        """Return a `GitRepo` instance.
+
+        Parameters
+        ----------
+        url: str
+            URL pointing to the GitHub repository.
+        branch: str
+            Name of a branch on the GitHub repository.
+        path: Path
+            Path to a directory in which the repository is cloned into. If
+            `path` points to an existing directory, the repository will be
+            cloned into `path / branch`.
+        commit: str, optional
+            Commit hash (long). When specified the repository will reset to this
+            commit when cloning.
+        """
+        self.url = url
+        self.branch = branch
+        self.path = path / branch if path.is_dir() else path
+        self.commit = commit
+
+    def checkout(self, verbose=False):
+        """Checkout the source code.
+
+        Parameters
+        ----------
+        verbose: bool, optional
+            Enable or disable verbose output.
+        """
+        # TODO(Sean) the gitpython package provides an interface for displaying
+        # remote progress. See
+        # https://gitpython.readthedocs.io/en/stable/reference.html#git.remote.RemoteProgress
+        self.subprocess_handler.run_cmd(
+            f"git clone --branch {self.branch} -- {self.url} {self.path}",
+            verbose=verbose,
+        )
+        if self.commit:
+            if verbose:
+                print(f"Reset to commit {self.commit} (hard reset)")
+            repo = git.Repo(self.path)
+            repo.head.reset(self.commit, working_tree=True)
+        print(f"Successfully checked out {self.branch} - {self.get_revision()}")
+
+    def get_revision(self) -> str:
+        """Return the latest revision of the source code.
+
+        Returns
+        -------
+        str
+            Human readable string describing the latest revision.
+        """
+        repo = git.Repo(self.path)
+        return f"commit {repo.head.commit.hexsha}"
+
+    def get_branch_name(self) -> str:
+        """Return the branch name of the source code.
+
+        Returns
+        -------
+        str
+            Branch name of the source code.
+        """
+        return self.branch
+
+
+class SVNRepo(Repo):
+    """A concrete implementation of the `Repo` class using an SVN backend.
+
+    Attributes
+    ----------
+    subprocess_handler: SubprocessWrapper
+        Object for handling subprocess calls.
+    """
+
+    subprocess_handler: SubprocessWrapperInterface = SubprocessWrapper()
+
+    def __init__(
+        self,
+        svn_root: str,
+        branch_path: str,
+        path: Path,
+        revision: Optional[int] = None,
+    ) -> None:
+        """Return an `SVNRepo` instance.
+
+        Parameters
+        ----------
+        svn_root: str
+            URL pointing to the root of the SVN repository.
+        branch_path: str
+            Path to a branch relative to `svn_root`.
+        path: Path
+            Path to a directory in which the branch is checked out into. If
+            `path` points to an existing directory, the repository will be
+            cloned into `path / <branch_name>` where `<branch_name>` is the
+            basename of `branch_path`.
+        revision: int, optional
+            SVN revision number. When specified the branch will be set to this
+            revision on checkout.
+        """
+        self.svn_root = svn_root
+        self.branch_path = branch_path
+        self.revision = revision
+        self.path = path / Path(branch_path).name if path.is_dir() else path
+
+    def checkout(self, verbose=False):
+        """Checkout the source code.
+
+        Parameters
+        ----------
+        verbose: bool, optional
+            Enable or disable verbose output. By default `verbose` is `False`.
+        """
+        cmd = "svn checkout"
+
+        if self.revision:
+            cmd += f" -r {self.revision}"
+
+        cmd += f" {internal.CABLE_SVN_ROOT}/{self.branch_path} {self.path}"
+
+        self.subprocess_handler.run_cmd(cmd, verbose=verbose)
+
+        print(f"Successfully checked out {self.path.name} - {self.get_revision()}")
+
+    def get_revision(self) -> str:
+        """Return the latest revision of the source code.
+
+        Returns
+        -------
+        str
+            Human readable string describing the latest revision.
+        """
+        proc = self.subprocess_handler.run_cmd(
+            f"svn info --show-item last-changed-revision {self.path}",
+            capture_output=True,
+        )
+        return f"last-changed-revision {proc.stdout.strip()}"
+
+    def get_branch_name(self) -> str:
+        """Return the branch name of the source code.
+
+        Returns
+        -------
+        str
+            Branch name of the source code.
+        """
+        return Path(self.branch_path).name
+
+
+class RepoSpecError(Exception):
+    """A custom exception class for repository spec errors."""
+
+
+def create_repo(spec: dict, path: Path) -> Repo:
+    """A factory function which returns `Repo` objects.
+
+    Parameters
+    ----------
+    spec: dict
+        Specifies a repository object from the `repo` key in the benchcab
+        configuration file.
+    path: Path
+        Path to a directory in which the repository is checked out to.
+
+    Returns
+    -------
+    Repo
+        A subclass instance of `Repo`.
+    """
+    if "git" in spec:
+        if "url" not in spec["git"]:
+            spec["git"]["url"] = internal.CABLE_GIT_URL
+        return GitRepo(path=path, **spec["git"])
+    if "svn" in spec:
+        return SVNRepo(svn_root=internal.CABLE_SVN_ROOT, path=path, **spec["svn"])
+    raise RepoSpecError

--- a/docs/user_guide/config_options.md
+++ b/docs/user_guide/config_options.md
@@ -201,9 +201,11 @@ realisations:
         branch: main
 ```
 
-[`svn`](#+repo.svn){ #+repo.svn}
+#### [`svn`](#+repo.svn){ #+repo.svn}
 
-: **Default:** _optional key_. :octicons-dash-24: Specify a branch from the CABLE SVN repository (`https://trac.nci.org.au/svn/cable`).
+Contains settings to specify a branch from the CABLE SVN repository (`https://trac.nci.org.au/svn/cable`).
+
+This key is _optional_. No default.
 
 ```yaml
 realisations:

--- a/docs/user_guide/config_options.md
+++ b/docs/user_guide/config_options.md
@@ -246,9 +246,11 @@ realisations:
         revision: 1234
 ```
 
-[`git`](#+repo.git){ #+repo.git}
+#### [`git`](#+repo.git){ #+repo.git}
 
-: **Default:** _optional key_. :octicons-dash-24: Specify a branch on the GitHub repository. By default, the [CABLE GitHub repository][cable-github] will be cloned (see [`url`](#+repo.git.url) to use a separate GitHub repository).
+Contains settings to specify a branch on the GitHub repository. By default, the [CABLE GitHub repository][cable-github] will be cloned (see [`url`](#+repo.git.url) to specify another GitHub repository).
+
+This key is _optional_. No default.
 
 ```yaml
 realisations:

--- a/docs/user_guide/config_options.md
+++ b/docs/user_guide/config_options.md
@@ -164,147 +164,184 @@ fluxsites:
 
 ## realisations
 
-Entries for each CABLE branch to use. Each entry is a dictionary, `{}`, that contains the following keys.
+Entries for each CABLE branch to use. Each entry is a key-value pair and are listed as follows:
 
 ```yaml
-realisations: [
-  { # head of the trunk
-    path: "trunk",
-  },
-  { # some development branch
-    path: "branches/Users/foo/my_branch",
-    patch: {
-      cable: {
-        cable_user: {
+realisations:
+  # head of the trunk (SVN)
+  - repo:
+      svn:
+        branch_path: trunk
+  # some development branch
+  - repo:
+      svn:
+        branch_path: branches/Users/foo/my_branch
+    patch:
+      cable:
+        cable_user:
           FWSOIL_SWITCH: "Lai and Ktaul 2000"
-        }
-      }
-    },
-    patch_remove: {
-      cable: {
+    patch_remove:
+      cable:
         soilparmnew: nil
-      }
-    }
-  }
-]
 ```
 
-[`path`](#+realisation.path){ #+realisation.path }
+### [repo](#repo)
 
-: **Default:** _required key, no default_. :octicons-dash-24: The path of the branch relative to the SVN root of the CABLE repository (`https://trac.nci.org.au/svn/cable`).
+: **Default:** _required key, no default_. :octicons-dash-24: Specify the CABLE repository to test against. The `repo` key must specify either the [`svn`](#+repo.svn) key or the [`git`](#+repo.git) key.
 
 ```yaml
-realisations: [
-  { # head of the trunk
-    path: "trunk", # (1) 
-  },
-  { # some development branch
-    path: "branches/Users/foo/my_branch", # (2)
-  }
-]
+realisations:
+  - repo:
+      svn:
+        branch_path: trunk
+  - repo:
+      git:
+        branch: main
+```
 
+[`svn`](#+repo.svn){ #+repo.svn}
+
+: **Default:** _optional key_. :octicons-dash-24: Specify a branch from the CABLE SVN repository (`https://trac.nci.org.au/svn/cable`).
+
+```yaml
+realisations:
+  - repo:
+      svn:
+        branch_path: branches/Users/foo/my_branch
+        revision: 1234
+```
+
+[`branch_path`](#+repo.svn.branch_path){ #+repo.svn.branch_path}
+
+: **Default:** _required key, no default_. :octicons-dash-24: Specify the branch path relative to the SVN root of the CABLE repository (`https://trac.nci.org.au/svn/cable`).
+
+```yaml
+realisations:
+  # head of the trunk
+  - repo:
+      svn:
+        branch_path: trunk # (1)
+  # some development branch
+  - repo:
+      svn:
+        branch_path: branches/Users/foo/my_branch # (2)
 ```
 
 1. To checkout `https://trac.nci.org.au/svn/cable/trunk`
 2. To checkout `https://trac.nci.org.au/svn/cable/branches/Users/foo/my_branch`
 
-[`name`](#+realisation.name){ #+realisation.name }
+[`revision`](#+repo.svn.revision){ #+repo.svn.revision}
 
-: **Default:** base name of [path](#+realisation.path), _optional key_. :octicons-dash-24: An alias name used internally by `benchcab` for the branch. The `name` key also specifies the directory name when checking out the branch, that is, `name` is the optional `PATH` argument to `svn checkout`.
+: **Default:** HEAD of the branch is checked out, _optional key_. :octicons-dash-24: Specify the revision number to checkout for the branch. This option can be used to ensure the reproducibility of the tests.
 
 ```yaml
-realisations: [
-  { # head of the trunk
-    path: "trunk",
-  },
-  { # some development branch
-    path: "branches/Users/foo/my_branch", 
-    name: "my_feature", # (1)
-  }
-]
+realisations:
+  - repo:
+      svn:
+        branch_path: branches/Users/foo/my_branch
+        revision: 1234
+```
 
+[`git`](#+repo.git){ #+repo.git}
+
+: **Default:** _optional key_. :octicons-dash-24: Specify a branch on the GitHub repository. By default, the [CABLE GitHub repository][cable-github] will be cloned (see [`url`](#+repo.git.url) to use a separate GitHub repository).
+
+```yaml
+realisations:
+  - repo:
+      git:
+        branch: my_branch
+        commit: 067b1f4a570385fce01552fdf96ced0adbbe17eb
+        url: https://github.com/SeanBryan51/CABLE.git
+```
+
+[`branch`](#+repo.git.branch){ #+repo.git.branch}
+
+: **Default:** _required key, no default_. :octicons-dash-24: Specify the GitHub branch name to be checked out.
+
+```yaml
+realisations:
+  - repo:
+      git:
+        branch: my_branch
+```
+
+[`commit`](#+repo.git.commit){ #+repo.git.commit}
+
+: **Default:** unset, _optional key_. :octicons-dash-24: Specify a specific commit to use for the branch.
+
+```yaml
+realisations:
+  - repo:
+      git:
+        branch: my_branch
+        commit: 067b1f4a570385fce01552fdf96ced0adbbe17eb
+```
+
+[`url`](#+repo.git.url){ #+repo.git.url}
+
+: **Default:** URL of the [CABLE GitHub repository][cable-github], _optional key_. :octicons-dash-24: Specify the GitHub repository url to clone from when checking out the branch.
+
+### [name](#name)
+
+: **Default:** base name of [branch_path](#+repo.svn.branch_path) if an SVN repository is given, for Git repositories the default is the branch name, _optional key_. :octicons-dash-24: An alias name used internally by `benchcab` for the branch. The `name` key also specifies the directory name of the source code when retrieving from SVN or GitHub.
+
+```yaml
+realisations:
+  - repo:
+      svn:
+        branch_path: branches/Users/foo/my_branch
+      name: my_feature # (1)
 ```
 
 1. Checkout the branch in the directory `src/my_feature`
 
-[`build_script`](#+realisation.build_script){ #+realisation.build_script }
+### [build_script](#build_script)
 
-: **Default:** unset, _optional key_. :octicons-dash-24: The path to a custom shell script to build the code in that branch, relative to the name of the branch. **Note:** any lines in the provided shell script that call the [environment modules API][environment-modules] will be ignored. To specify modules to use for the build script, please specify them using the [`modules`](#modules) key.
-
-```yaml
-realisations: [
-  { # head of the trunk
-    path: "trunk",
-  },
-  { # some development branch
-    path: "branches/Users/foo/my_branch", 
-    build_script: "offline/build.sh", # (1)
-  }
-]
-```
-
-1. Uses the build script stored by `benchcab` as `src/my_branch/offline/build.sh`
-
-[`revision`](#+realisation.revision){ #+realisation.revision }
-
-: **Default:** HEAD of the branch is checked out, _optional key_. :octicons-dash-24: The revision number to checkout for the branch. This option can be used to ensure the reproducibility of the tests.
+: **Default:** unset, _optional key_. :octicons-dash-24: The path to a custom shell script to build the code in that branch, relative to the repository root directory. **Note:** any lines in the provided shell script that call the [environment modules API][environment-modules] will be ignored. To specify modules to use for the build script, please specify them using the [`modules`](#modules) key.
 
 ```yaml
-realisations: [
-  { # head of the trunk
-    path: "trunk",
-  },
-  { # some development branch
-    path: "branches/Users/foo/my_branch", 
-    revision: 439,
-  }
-]
+realisations:
+  # head of the trunk
+  - path: trunk
+  # some development branch
+  - path: branches/Users/foo/my_branch
+    build_script: offline/build.sh
 ```
 
-[`patch`](#+realisation.patch){ #+realisation.patch }
+### [patch](#patch)
 
 : **Default:** unset, _optional key_. :octicons-dash-24: Branch-specific namelist settings for `cable.nml`. Settings specified in `patch` get "patched" to the base namelist settings used for both branches. Any namelist settings specified here will overwrite settings defined in the default namelist file and in the science configurations. This means these settings will be set as stipulated in the `patch` for this branch for all science configurations run by `benchcab`.
 : The `patch` key must be a dictionary-like data structure that is compliant with the [`f90nml`][f90nml-github] python package.
 
 ```yaml
-realisations: [
-  { # head of the trunk
-    path: "trunk",
-  },
-  { # some development branch
-    path: "branches/Users/foo/my_branch",
-    patch: { # (1)
-      cable: {
-        cable_user: {
-          FWSOIL_SWITCH: "Lai and Ktaul 2000", 
-        }
-      }
-    }
-  }
-]
+realisations:
+  # head of the trunk
+  - path: trunk
+  # some development branch
+  - path: branches/Users/foo/my_branch
+    patch:  # (1)
+      cable:
+        cable_user:
+          FWSOIL_SWITCH: "Lai and Ktaul 2000"
 ```
 
 1. Sets FWSOIL_SWITCH to "Lai and Ktaul 2000" for all science configurations for this branch
 
-[`patch_remove`](#+realisation.path_remove){#+realisation.patch_remove}
+### [patch_remove](#patch_remove)
 
 : **Default:** unset, no effect, _optional key. :octicons-dash-24: Specifies branch-specific namelist settings to be removed from the `cable.nml` namelist settings. When the `patch_remove` key is specified, the specified namelists are removed from all namelist files for this branch for all science configurations run by `benchcab`. When specifying a namelist parameter in `patch_remove`, the value of the namelist parameter is ignored.
 : The `patch_remove` key must be a dictionary-like data structure that is compliant with the [`f90nml`][f90nml-github] python package.
 
 ```yaml
-realisations: [
-  { # head of the trunk
-    path: "trunk",
-  },
-  { # some development branch
-    path: "branches/Users/foo/my_branch",
-    patch_remove: {
-      cable: {
-        soilparmnew: nil, # (1)
-      }
-    }
-  }
-]
+realisations:
+  # head of the trunk
+  - path: trunk
+  # some development branch
+  - path: branches/Users/foo/my_branch
+    patch_remove:
+      cable:
+        soilparmnew: nil # (1)
 ```
 
 1. The value is ignored and does not have to be a possible value for the namelist option.
@@ -341,3 +378,4 @@ science_configurations: [
 [f90nml-github]: https://github.com/marshallward/f90nml
 [environment-modules]: https://modules.sourceforge.net/
 [nci-pbs-directives]: https://opus.nci.org.au/display/Help/PBS+Directives+Explained
+[cable-github]: https://github.com/CABLE-LSM/CABLE

--- a/docs/user_guide/config_options.md
+++ b/docs/user_guide/config_options.md
@@ -187,7 +187,9 @@ realisations:
 
 ### [repo](#repo)
 
-: **Default:** _required key, no default_. :octicons-dash-24: Specify the CABLE repository to test against. The `repo` key must specify either the [`svn`](#+repo.svn) key or the [`git`](#+repo.git) key.
+Contains settings to specify the CABLE branch to test against. 
+
+This key is _required_. The `repo` key must specify either the [`svn`](#+repo.svn) key or the [`git`](#+repo.git) key.
 
 ```yaml
 realisations:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -82,7 +82,11 @@ class TestGetExePath:
         )
 
 
-@pytest.mark.skip(reason="The `checkout` method was removed.")
+# TODO(Sean) remove for issue https://github.com/CABLE-LSM/benchcab/issues/211
+@pytest.mark.skip(
+    reason="""Skip tests for `checkout` until tests for repo.py
+    have been implemented."""
+)
 class TestCheckout:
     """Tests for `Model.checkout()`."""
 
@@ -119,7 +123,11 @@ class TestCheckout:
         assert buf.getvalue() == expected
 
 
-@pytest.mark.skip(reason="The `svn_info_show_item` method was removed.")
+# TODO(Sean) remove for issue https://github.com/CABLE-LSM/benchcab/issues/211
+@pytest.mark.skip(
+    reason="""Skip tests for `svn_info_show_item` until tests for repo.py
+    have been implemented."""
+)
 class TestSVNInfoShowItem:
     """Tests for `Model.svn_info_show_item()`."""
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -14,66 +14,92 @@ import pytest
 
 from benchcab import internal
 from benchcab.model import Model, remove_module_lines
+from benchcab.utils.repo import Repo
 
 from .conftest import DEFAULT_STDOUT
 
 
 @pytest.fixture()
-def repo(mock_cwd, mock_subprocess_handler, mock_environment_modules_handler):
+def mock_repo():
+    """Return a mock implementation of the `Repo` interface."""
+
+    class MockRepo(Repo):
+        """A mock implementation of the `Repo` interface used for testing."""
+
+        def __init__(self) -> None:
+            self.handle = "trunk"
+
+        def checkout(self, verbose=False):
+            pass
+
+        def get_branch_name(self) -> str:
+            return self.handle
+
+        def get_revision(self) -> str:
+            pass
+
+    return MockRepo()
+
+
+@pytest.fixture()
+def model(
+    mock_repo, mock_cwd, mock_subprocess_handler, mock_environment_modules_handler
+):
     """Return a mock `Model` instance for testing against."""
-    _repo = Model(path="trunk")
-    _repo.root_dir = mock_cwd
-    _repo.subprocess_handler = mock_subprocess_handler
-    _repo.modules_handler = mock_environment_modules_handler
-    return _repo
+    _model = Model(repo=mock_repo)
+    _model.root_dir = mock_cwd
+    _model.subprocess_handler = mock_subprocess_handler
+    _model.modules_handler = mock_environment_modules_handler
+    return _model
 
 
-class TestRepoID:
-    """Tests for `Model.repo_id`."""
+class TestModelID:
+    """Tests for `Model.model_id`."""
 
-    def test_set_and_get_repo_id(self, repo):
-        """Success case: set and get repository ID."""
+    def test_set_and_get_model_id(self, model):
+        """Success case: set and get model ID."""
         val = 456
-        repo.repo_id = val
-        assert repo.repo_id == val
+        model.model_id = val
+        assert model.model_id == val
 
-    def test_undefined_repo_id(self, repo):
-        """Failure case: access undefined repository ID."""
-        repo.repo_id = None
+    def test_undefined_model_id(self, model):
+        """Failure case: access undefined model ID."""
+        model.model_id = None
         with pytest.raises(
-            RuntimeError, match="Attempting to access undefined repo ID"
+            RuntimeError, match="Attempting to access undefined model ID"
         ):
-            _ = repo.repo_id
+            _ = model.model_id
 
 
 class TestGetExePath:
-    """Tests for `CableRepository.get_exe_path()`."""
+    """Tests for `Model.get_exe_path()`."""
 
-    def test_serial_exe_path(self, repo, mock_cwd):
+    def test_serial_exe_path(self, model, mock_cwd):
         """Success case: get path to serial executable."""
         assert (
-            repo.get_exe_path()
-            == mock_cwd / internal.SRC_DIR / repo.name / "offline" / internal.CABLE_EXE
+            model.get_exe_path()
+            == mock_cwd / internal.SRC_DIR / model.name / "offline" / internal.CABLE_EXE
         )
 
 
+@pytest.mark.skip(reason="The `checkout` method was removed.")
 class TestCheckout:
     """Tests for `Model.checkout()`."""
 
-    def test_checkout_command_execution(self, repo, mock_cwd, mock_subprocess_handler):
+    def test_checkout_command_execution(self, model, mock_cwd, mock_subprocess_handler):
         """Success case: `svn checkout` command is executed."""
-        repo.checkout()
+        model.checkout()
         assert (
             f"svn checkout https://trac.nci.org.au/svn/cable/trunk {mock_cwd}/src/trunk"
             in mock_subprocess_handler.commands
         )
 
     def test_checkout_command_execution_with_revision_number(
-        self, repo, mock_cwd, mock_subprocess_handler
+        self, model, mock_cwd, mock_subprocess_handler
     ):
         """Success case: `svn checkout` command is executed with specified revision number."""
-        repo.revision = 9000
-        repo.checkout()
+        model.revision = 9000
+        model.checkout()
         assert (
             f"svn checkout -r 9000 https://trac.nci.org.au/svn/cable/trunk {mock_cwd}/src/trunk"
             in mock_subprocess_handler.commands
@@ -86,20 +112,21 @@ class TestCheckout:
             (True, f"Successfully checked out trunk at revision {DEFAULT_STDOUT}\n"),
         ],
     )
-    def test_standard_output(self, repo, verbosity, expected):
+    def test_standard_output(self, model, verbosity, expected):
         """Success case: test standard output."""
         with contextlib.redirect_stdout(io.StringIO()) as buf:
-            repo.checkout(verbose=verbosity)
+            model.checkout(verbose=verbosity)
         assert buf.getvalue() == expected
 
 
+@pytest.mark.skip(reason="The `svn_info_show_item` method was removed.")
 class TestSVNInfoShowItem:
     """Tests for `Model.svn_info_show_item()`."""
 
-    def test_svn_info_command_execution(self, repo, mock_subprocess_handler, mock_cwd):
+    def test_svn_info_command_execution(self, model, mock_subprocess_handler, mock_cwd):
         """Success case: call svn info command and get result."""
         assert (
-            repo.svn_info_show_item("some-mock-item") == mock_subprocess_handler.stdout
+            model.svn_info_show_item("some-mock-item") == mock_subprocess_handler.stdout
         )
         assert (
             f"svn info --show-item some-mock-item {mock_cwd}/src/trunk"
@@ -107,12 +134,12 @@ class TestSVNInfoShowItem:
         )
 
     def test_white_space_removed_from_standard_output(
-        self, repo, mock_subprocess_handler
+        self, model, mock_subprocess_handler
     ):
         """Success case: test leading and trailing white space is removed from standard output."""
         mock_subprocess_handler.stdout = " \n\n mock standard output \n\n"
         assert (
-            repo.svn_info_show_item("some-mock-item")
+            model.svn_info_show_item("some-mock-item")
             == mock_subprocess_handler.stdout.strip()
         )
 
@@ -121,18 +148,18 @@ class TestPreBuild:
     """Tests for `Model.pre_build()`."""
 
     @pytest.fixture(autouse=True)
-    def _setup(self, repo):
+    def _setup(self, model):
         """Setup precondition for `Model.pre_build()`."""
-        (internal.SRC_DIR / repo.name / "offline").mkdir(parents=True)
-        (internal.SRC_DIR / repo.name / "offline" / "Makefile").touch()
-        (internal.SRC_DIR / repo.name / "offline" / "parallel_cable").touch()
-        (internal.SRC_DIR / repo.name / "offline" / "serial_cable").touch()
-        (internal.SRC_DIR / repo.name / "offline" / "foo.f90").touch()
+        (internal.SRC_DIR / model.name / "offline").mkdir(parents=True)
+        (internal.SRC_DIR / model.name / "offline" / "Makefile").touch()
+        (internal.SRC_DIR / model.name / "offline" / "parallel_cable").touch()
+        (internal.SRC_DIR / model.name / "offline" / "serial_cable").touch()
+        (internal.SRC_DIR / model.name / "offline" / "foo.f90").touch()
 
-    def test_source_files_and_scripts_are_copied_to_tmp_dir(self, repo):
+    def test_source_files_and_scripts_are_copied_to_tmp_dir(self, model):
         """Success case: test source files and scripts are copied to .tmp."""
-        repo.pre_build()
-        tmp_dir = internal.SRC_DIR / repo.name / "offline" / ".tmp"
+        model.pre_build()
+        tmp_dir = internal.SRC_DIR / model.name / "offline" / ".tmp"
         assert (tmp_dir / "Makefile").exists()
         assert (tmp_dir / "parallel_cable").exists()
         assert (tmp_dir / "serial_cable").exists()
@@ -155,10 +182,10 @@ class TestPreBuild:
             ),
         ],
     )
-    def test_standard_output(self, repo, verbosity, expected):
+    def test_standard_output(self, model, verbosity, expected):
         """Success case: test standard output."""
         with contextlib.redirect_stdout(io.StringIO()) as buf:
-            repo.pre_build(verbose=verbosity)
+            model.pre_build(verbose=verbosity)
         assert buf.getvalue() == expected
 
 
@@ -188,19 +215,19 @@ class TestRunBuild:
         }
 
     @pytest.fixture(autouse=True)
-    def _setup(self, repo, netcdf_root):
+    def _setup(self, model, netcdf_root):
         """Setup precondition for `Model.run_build()`."""
-        (internal.SRC_DIR / repo.name / "offline" / ".tmp").mkdir(parents=True)
+        (internal.SRC_DIR / model.name / "offline" / ".tmp").mkdir(parents=True)
 
         # This is required so that we can use the NETCDF_ROOT environment variable
         # when running `make`, and `serial_cable` and `parallel_cable` scripts:
         os.environ["NETCDF_ROOT"] = netcdf_root
 
     def test_build_command_execution(
-        self, repo, mock_subprocess_handler, modules, netcdf_root
+        self, model, mock_subprocess_handler, modules, netcdf_root
     ):
         """Success case: test build commands are run."""
-        repo.run_build(modules)
+        model.run_build(modules)
         assert mock_subprocess_handler.commands == [
             "make -f Makefile",
             './serial_cable "ifort" "-O2 -fp-model precise"'
@@ -209,10 +236,10 @@ class TestRunBuild:
         ]
 
     def test_modules_loaded_at_runtime(
-        self, repo, mock_environment_modules_handler, modules
+        self, model, mock_environment_modules_handler, modules
     ):
         """Success case: test modules are loaded at runtime."""
-        repo.run_build(modules)
+        model.run_build(modules)
         assert (
             "module load " + " ".join(modules)
         ) in mock_environment_modules_handler.commands
@@ -221,10 +248,10 @@ class TestRunBuild:
         ) in mock_environment_modules_handler.commands
 
     def test_commands_are_run_with_environment_variables(
-        self, repo, mock_subprocess_handler, modules, env
+        self, model, mock_subprocess_handler, modules, env
     ):
         """Success case: test commands are run with the correct environment variables."""
-        repo.run_build(modules)
+        model.run_build(modules)
         for kv in env.items():
             assert kv in mock_subprocess_handler.env.items()
 
@@ -235,10 +262,10 @@ class TestRunBuild:
             (True, "Loading modules: foo bar\nUnloading modules: foo bar\n"),
         ],
     )
-    def test_standard_output(self, repo, modules, verbosity, expected):
+    def test_standard_output(self, model, modules, verbosity, expected):
         """Success case: test standard output."""
         with contextlib.redirect_stdout(io.StringIO()) as buf:
-            repo.run_build(modules, verbose=verbosity)
+            model.run_build(modules, verbose=verbosity)
         assert buf.getvalue() == expected
 
 
@@ -246,17 +273,19 @@ class TestPostBuild:
     """Tests for `Model.post_build()`."""
 
     @pytest.fixture(autouse=True)
-    def _setup(self, repo):
+    def _setup(self, model):
         """Setup precondition for `Model.post_build()`."""
-        (internal.SRC_DIR / repo.name / "offline" / ".tmp").mkdir(parents=True)
-        (internal.SRC_DIR / repo.name / "offline" / ".tmp" / internal.CABLE_EXE).touch()
+        (internal.SRC_DIR / model.name / "offline" / ".tmp").mkdir(parents=True)
+        (
+            internal.SRC_DIR / model.name / "offline" / ".tmp" / internal.CABLE_EXE
+        ).touch()
 
-    def test_exe_moved_to_offline_dir(self, repo):
+    def test_exe_moved_to_offline_dir(self, model):
         """Success case: test executable is moved to offline directory."""
-        repo.post_build()
-        tmp_dir = internal.SRC_DIR / repo.name / "offline" / ".tmp"
+        model.post_build()
+        tmp_dir = internal.SRC_DIR / model.name / "offline" / ".tmp"
         assert not (tmp_dir / internal.CABLE_EXE).exists()
-        offline_dir = internal.SRC_DIR / repo.name / "offline"
+        offline_dir = internal.SRC_DIR / model.name / "offline"
         assert (offline_dir / internal.CABLE_EXE).exists()
 
     @pytest.mark.parametrize(
@@ -266,10 +295,10 @@ class TestPostBuild:
             (True, "mv src/trunk/offline/.tmp/cable src/trunk/offline/cable\n"),
         ],
     )
-    def test_standard_output(self, repo, verbosity, expected):
+    def test_standard_output(self, model, verbosity, expected):
         """Success case: test non-verbose standard output."""
         with contextlib.redirect_stdout(io.StringIO()) as buf:
-            repo.post_build(verbose=verbosity)
+            model.post_build(verbose=verbosity)
         assert buf.getvalue() == expected
 
 
@@ -277,15 +306,15 @@ class TestCustomBuild:
     """Tests for `Model.custom_build()`."""
 
     @pytest.fixture()
-    def build_script(self, repo):
+    def build_script(self, model):
         """Create a custom build script and return its path.
 
         The return value is the path relative to root directory of the repository.
         """
-        _build_script = internal.SRC_DIR / repo.name / "my-custom-build.sh"
+        _build_script = internal.SRC_DIR / model.name / "my-custom-build.sh"
         _build_script.parent.mkdir(parents=True)
         _build_script.touch()
-        return _build_script.relative_to(internal.SRC_DIR / repo.name)
+        return _build_script.relative_to(internal.SRC_DIR / model.name)
 
     @pytest.fixture()
     def modules(self):
@@ -293,19 +322,19 @@ class TestCustomBuild:
         return ["foo", "bar"]
 
     def test_build_command_execution(
-        self, repo, mock_subprocess_handler, build_script, modules
+        self, model, mock_subprocess_handler, build_script, modules
     ):
         """Success case: execute the build command for a custom build script."""
-        repo.build_script = str(build_script)
-        repo.custom_build(modules)
+        model.build_script = str(build_script)
+        model.custom_build(modules)
         assert "./tmp-build.sh" in mock_subprocess_handler.commands
 
     def test_modules_loaded_at_runtime(
-        self, repo, mock_environment_modules_handler, build_script, modules
+        self, model, mock_environment_modules_handler, build_script, modules
     ):
         """Success case: test modules are loaded at runtime."""
-        repo.build_script = str(build_script)
-        repo.custom_build(modules)
+        model.build_script = str(build_script)
+        model.custom_build(modules)
         assert (
             "module load " + " ".join(modules)
         ) in mock_environment_modules_handler.commands
@@ -336,25 +365,25 @@ class TestCustomBuild:
             ),
         ],
     )
-    def test_standard_output(self, repo, build_script, modules, verbosity, expected):
+    def test_standard_output(self, model, build_script, modules, verbosity, expected):
         """Success case: test non-verbose standard output for a custom build script."""
-        repo.build_script = str(build_script)
+        model.build_script = str(build_script)
         with contextlib.redirect_stdout(io.StringIO()) as buf:
-            repo.custom_build(modules, verbose=verbosity)
+            model.custom_build(modules, verbose=verbosity)
         assert buf.getvalue() == expected
 
-    def test_file_not_found_exception(self, repo, build_script, modules, mock_cwd):
+    def test_file_not_found_exception(self, model, build_script, modules, mock_cwd):
         """Failure case: cannot find custom build script."""
-        build_script_path = mock_cwd / internal.SRC_DIR / repo.name / build_script
+        build_script_path = mock_cwd / internal.SRC_DIR / model.name / build_script
         build_script_path.unlink()
-        repo.build_script = str(build_script)
+        model.build_script = str(build_script)
         with pytest.raises(
             FileNotFoundError,
             match=f"The build script, {build_script_path}, could not be "
             "found. Do you need to specify a different build script with the 'build_script' "
             "option in config.yaml?",
         ):
-            repo.custom_build(modules)
+            model.custom_build(modules)
 
 
 class TestRemoveModuleLines:


### PR DESCRIPTION
Currently benchcab can only fetch repositories from the subversion repository. This change adds the ability to specify and checkout repositories from GitHub so that benchcab can be used when CABLE moves over to Git.

Fixes #183, #197