### PR TITLE
License and branding

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -1,0 +1,13 @@
+   Copyright 2022 ACCESS-NRI
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # benchcab
 
-[![Documentation status][readthedocs_badge]][docs] [![Test coverage][codecov_badge]][codecov_summary] [![Conda package status][conda_badge]][conda]
+[![Documentation status][readthedocs_badge]][docs] [![Test coverage][codecov_badge]][codecov_summary] [![Conda package status][conda_badge]][conda] [![GitHub License][license_badge]][license]
+
 
 `benchcab` is a testing framework that tests the CABLE land surface model across a range of model configurations and model versions. The tool:
 - checks out the model versions specified by the user
@@ -18,8 +19,10 @@ The full documentation is available at [benchcab.readthedocs.io][docs].
 
 [conda_badge]: https://img.shields.io/conda/v/accessnri/benchcab
 [codecov_badge]: https://codecov.io/gh/CABLE-LSM/benchcab/branch/master/graph/badge.svg?token=JJYE1YZDXQ
-[readthedocs_badge]: https://readthedocs.org/projects/benchcab/badge
+[readthedocs_badge]: https://readthedocs.org/projects/benchcab/badge/?version=stable
+[license_badge]: https://img.shields.io/github/license/CABLE-LSM/benchcab
 [conda]: https://anaconda.org/accessnri/benchcab
 [codecov_summary]: https://codecov.io/gh/CABLE-LSM/benchcab
 [docs]: https://benchcab.readthedocs.io
+[license]: https://github.com/CABLE-LSM/benchcab/blob/main/LICENSE
 [meorg]: https://modelevaluation.org

--- a/benchcab/__init__.py
+++ b/benchcab/__init__.py
@@ -1,3 +1,6 @@
+# Copyright 2022 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
+
 import importlib.metadata
 
 try:

--- a/benchcab/benchcab.py
+++ b/benchcab/benchcab.py
@@ -1,3 +1,6 @@
+# Copyright 2022 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
+
 """Contains the benchcab application class."""
 
 import grp

--- a/benchcab/cli.py
+++ b/benchcab/cli.py
@@ -1,3 +1,6 @@
+# Copyright 2022 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
+
 """Contains the definition of the command line interface used for `benchcab`."""
 
 import argparse

--- a/benchcab/comparison.py
+++ b/benchcab/comparison.py
@@ -1,3 +1,6 @@
+# Copyright 2022 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
+
 """A module containing functions and data structures for running comparison tasks."""
 
 import multiprocessing

--- a/benchcab/config.py
+++ b/benchcab/config.py
@@ -1,3 +1,6 @@
+# Copyright 2022 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
+
 """A module containing all *_config() functions."""
 from pathlib import Path
 
@@ -8,7 +11,6 @@ import benchcab.utils as bu
 
 
 class ConfigValidationException(Exception):
-
     def __init__(self, validator: Validator):
         """Config validation exception.
 
@@ -19,11 +21,11 @@ class ConfigValidationException(Exception):
         """
 
         # Nicely format the errors.
-        errors = [f'{k} = {v}' for k, v in validator.errors.items()]
+        errors = [f"{k} = {v}" for k, v in validator.errors.items()]
 
-        # Assemble the error message and 
-        msg = '\n\nThe following errors were raised when validating the config file.\n'
-        msg += '\n'.join(errors) + '\n'
+        # Assemble the error message and
+        msg = "\n\nThe following errors were raised when validating the config file.\n"
+        msg += "\n".join(errors) + "\n"
 
         # Raise to super.
         super().__init__(msg)
@@ -47,16 +49,16 @@ def validate_config(config: dict) -> bool:
     ConfigValidationException
         Raised when the configuration file fails validation.
     """
-    
+
     # Load the schema
-    schema = bu.load_package_data('config-schema.yml')
+    schema = bu.load_package_data("config-schema.yml")
 
     # Create a validator
     v = Validator(schema)
 
     # Validate
     is_valid = v.validate(config)
-    
+
     # Valid
     if is_valid:
         return True
@@ -77,7 +79,7 @@ def read_config(config_path: str) -> dict:
     -------
     dict
         Configuration dict.
-    
+
     Raises
     ------
     ConfigValidationError

--- a/benchcab/environment_modules.py
+++ b/benchcab/environment_modules.py
@@ -1,3 +1,6 @@
+# Copyright 2022 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
+
 """Contains a wrapper around the environment modules API."""
 
 import contextlib

--- a/benchcab/fluxsite.py
+++ b/benchcab/fluxsite.py
@@ -1,3 +1,6 @@
+# Copyright 2022 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
+
 """A module containing functions and data structures for running fluxsite tasks."""
 
 import multiprocessing

--- a/benchcab/internal.py
+++ b/benchcab/internal.py
@@ -1,3 +1,6 @@
+# Copyright 2022 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
+
 """internal.py: define all runtime constants in a single file."""
 
 import os
@@ -75,9 +78,7 @@ FLUXSITE_DIRS["TASKS"] = FLUXSITE_DIRS["RUN"] / "tasks"
 FLUXSITE_DIRS["ANALYSIS"] = FLUXSITE_DIRS["RUN"] / "analysis"
 
 # Relative path to directory that stores bitwise comparison results
-FLUXSITE_DIRS["BITWISE_CMP"] = (
-    FLUXSITE_DIRS["ANALYSIS"] / "bitwise-comparisons"
-)
+FLUXSITE_DIRS["BITWISE_CMP"] = FLUXSITE_DIRS["ANALYSIS"] / "bitwise-comparisons"
 
 # Path to met files:
 MET_DIR = Path("/g/data/ks32/CLEX_Data/PLUMBER2/v1-0/Met/")

--- a/benchcab/model.py
+++ b/benchcab/model.py
@@ -1,3 +1,6 @@
+# Copyright 2022 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
+
 """A module containing functions and data structures for manipulating CABLE repositories."""
 
 import os

--- a/benchcab/utils/__init__.py
+++ b/benchcab/utils/__init__.py
@@ -1,3 +1,6 @@
+# Copyright 2022 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
+
 """Top-level utilities."""
 import pkgutil
 import json
@@ -8,10 +11,7 @@ from pathlib import Path
 
 
 # List of one-argument decoding functions.
-PACKAGE_DATA_DECODERS = dict(
-    json=json.loads,
-    yml=yaml.safe_load
-)
+PACKAGE_DATA_DECODERS = dict(json=json.loads, yml=yaml.safe_load)
 
 
 def get_installed_root() -> Path:
@@ -22,7 +22,7 @@ def get_installed_root() -> Path:
     Path
         Path to the installed root.
     """
-    return Path(resources.files('benchcab'))
+    return Path(resources.files("benchcab"))
 
 
 def load_package_data(filename: str) -> dict:
@@ -34,13 +34,13 @@ def load_package_data(filename: str) -> dict:
         Filename of the file to load out of the data directory.
     """
     # Work out the encoding of requested file.
-    ext = filename.split('.')[-1]
+    ext = filename.split(".")[-1]
 
     # Alias yaml and yml.
-    ext = ext if ext != 'yaml' else 'yml'
+    ext = ext if ext != "yaml" else "yml"
 
     # Extract from the installations data directory.
-    raw = pkgutil.get_data('benchcab', os.path.join('data', filename)).decode('utf-8')
+    raw = pkgutil.get_data("benchcab", os.path.join("data", filename)).decode("utf-8")
 
     # Decode and return.
     return PACKAGE_DATA_DECODERS[ext](raw)

--- a/benchcab/utils/fs.py
+++ b/benchcab/utils/fs.py
@@ -1,3 +1,6 @@
+# Copyright 2022 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
+
 """Contains utility functions for interacting with the file system."""
 
 import contextlib

--- a/benchcab/utils/pbs.py
+++ b/benchcab/utils/pbs.py
@@ -1,3 +1,6 @@
+# Copyright 2022 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
+
 """Contains helper functions for manipulating PBS job scripts."""
 
 from typing import Optional

--- a/benchcab/utils/subprocess.py
+++ b/benchcab/utils/subprocess.py
@@ -1,3 +1,6 @@
+# Copyright 2022 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
+
 """A module containing utility functions that wraps around the `subprocess` module."""
 
 import contextlib

--- a/benchcab/workdir.py
+++ b/benchcab/workdir.py
@@ -1,3 +1,6 @@
+# Copyright 2022 ACCESS-NRI and contributors. See the top-level COPYRIGHT file for details.
+# SPDX-License-Identifier: Apache-2.0
+
 """Functions for generating the directory structure used for `benchcab`."""
 
 import shutil

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,4 +8,8 @@ It is developed and maintained by the CABLE's user community and the ACCESS-NRI.
 
 `benchcab` is distributed under [an Apache License v2.0][apache-license].
 
+## Acknowledgements
+
+`benchcab` is a continuation of the efforts made by Martin De Kauwe ([@mdekauwe](https://github.com/mdekauwe)) and Gab Abramowitz ([@gabsun](https://github.com/gabsun)) in developing a CABLE benchmarking framework - we thank them for their contribution.
+
 [apache-license]: https://www.apache.org/licenses/LICENSE-2.0

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,4 +6,6 @@ It is developed and maintained by the CABLE's user community and the ACCESS-NRI.
 
 ## License
 
-`benchcab` is distributed under an Apache License v2.0.
+`benchcab` is distributed under [an Apache License v2.0][apache-license].
+
+[apache-license]: https://www.apache.org/licenses/LICENSE-2.0

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,3 +3,7 @@
 `benchcab` is an evaluation tool for the land surface model CABLE. `benchcab` is designed to perform set standard simulations with two versions of CABLE. These simulations are then analysed together in modelevaluation.org to assess the scientific strengths and gaps in the two CABLE versions.
 
 It is developed and maintained by the CABLE's user community and the ACCESS-NRI.
+
+## License
+
+`benchcab` is distributed under an Apache License v2.0.

--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -258,13 +258,13 @@ Once the benchmarking has finished running all the simulations, you need to uplo
 
 Please enter your questions as issues on [the benchcab repository][issues-benchcab].
 
-Alternatively, you can also post discussions or questions on [the ACCESS-Hive forum][hive-forum].
+Alternatively, you can also access the ACCESS-NRI User support via [the ACCESS-Hive forum][forum-support].
 
 [hh5_mynci]: https://my.nci.org.au/mancini/project/hh5
 [ks32_mynci]: https://my.nci.org.au/mancini/project/ks32
 [bench_example]: https://github.com/CABLE-LSM/bench_example.git
 [config_options]: config_options.md
-[hive-forum]: https://forum.access-hive.org.au
+[forum-support]: https://forum.access-hive.org.au/t/access-help-and-support/908
 [issues-benchcab]: https://github.com/CABLE-LSM/benchcab/issues
 [meorg]: https://modelevaluation.org/
 [model_profile_eg]: https://modelevaluation.org/model/display/fd5GFaJGYu7H4JpP5

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ repo_name: benchcab
 # Material default to a "master" branch, need to change to "main"
 edit_uri: edit/main/docs
 docs_dir: docs
+copyright: Copyright &copy; 2022 ACCESS-NRI
 
 theme:
   name: material


### PR DESCRIPTION
Fixes #118 and #108

- Add license and copyright files. 
- Add copyright notice to all the files and the documentation footer to follow [best practices](https://github.com/ACCESS-NRI/template/blob/main/README.md)
- Add license mention on documentation home page
- Direct help request to GitHub or forum user support.
- Add license badge in README