### PR TITLE
Move `experiment` key under `fluxsite`

### DIFF
--- a/benchcab/benchcab.py
+++ b/benchcab/benchcab.py
@@ -122,7 +122,9 @@ class Benchcab:
                 "science_configurations", internal.DEFAULT_SCIENCE_CONFIGURATIONS
             ),
             fluxsite_forcing_file_names=get_met_forcing_file_names(
-                config["experiment"]
+                config.get("fluxsite", {}).get(
+                    "experiment", internal.FLUXSITE_DEFAULT_EXPERIMENT
+                )
             ),
         )
         return self.tasks

--- a/benchcab/data/config-schema.yml
+++ b/benchcab/data/config-schema.yml
@@ -6,18 +6,6 @@ modules:
   schema:
     type: "string"
 
-experiment:
-  type: "string"
-  allowed: [
-    "five-site-test",
-    "forty-two-site-test",
-    "AU-Tum",
-    "AU-How",
-    "FI-Hyy",
-    "US-Var",
-    "US-Whs"
-  ]
-
 science_configurations:
   type: "list"
   schema: 
@@ -72,6 +60,18 @@ fluxsite:
   type: "dict"
   required: false
   schema:
+    experiment:
+      type: "string"
+      allowed: [
+        "five-site-test",
+        "forty-two-site-test",
+        "AU-Tum",
+        "AU-How",
+        "FI-Hyy",
+        "US-Var",
+        "US-Whs"
+      ]
+      required: false
     multiprocessing:
       type: "boolean"
       required: false

--- a/benchcab/data/test/config-invalid.yml
+++ b/benchcab/data/test/config-invalid.yml
@@ -1,7 +1,8 @@
 # A sample configuration that should fail validation.
 project: w97
 
-experiment:  NON EXISTENT EXPERIMENT!!!
+fluxsite:
+  experiment:  NON EXISTENT EXPERIMENT!!!
 
 realisations: [
   {

--- a/benchcab/data/test/config-valid.yml
+++ b/benchcab/data/test/config-valid.yml
@@ -17,8 +17,6 @@
 
 project: w97
 
-experiment: five-site-test
-
 realisations:
   - repo:
       svn:

--- a/benchcab/data/test/integration.sh
+++ b/benchcab/data/test/integration.sh
@@ -17,8 +17,6 @@ git reset --hard 6287539e96fc8ef36dc578201fbf9847314147fb
 cat > config.yaml << EOL
 project: $PROJECT
 
-experiment: AU-Tum
-
 realisations:
   - repo:
       svn:
@@ -34,9 +32,10 @@ modules: [
 ]
 
 fluxsite:
-    pbs:
-        storage:
-            - scratch/$PROJECT
+  experiment: AU-Tum
+  pbs:
+    storage:
+      - scratch/$PROJECT
 EOL
 
 benchcab run -v

--- a/benchcab/internal.py
+++ b/benchcab/internal.py
@@ -223,6 +223,8 @@ MEORG_EXPERIMENTS = {
     ],
 }
 
+FLUXSITE_DEFAULT_EXPERIMENT = "forty-two-site-test"
+
 OPTIONAL_COMMANDS = ["fluxsite-bitwise-cmp"]
 
 

--- a/docs/user_guide/config_options.md
+++ b/docs/user_guide/config_options.md
@@ -72,7 +72,7 @@ fluxsite:
 
 ### [experiment](#experiment)
 
-: **Default:** `forty-two-site-test`, _optional key_. :octicons-dash-24: Type of experiment to run. Experiments are defined in the **benchcab-evaluation** workspace on [modelevaluation.org][meorg]. This key specifies the met forcing files used in the test suite. To choose from:
+: **Default:** `forty-two-site-test`, _optional key_. :octicons-dash-24: Type of fluxsite experiment to run. Experiments are defined in the **benchcab-evaluation** workspace on [modelevaluation.org][meorg]. This key specifies the met forcing files used in the test suite. To choose from:
 
 : | Key value | Experiment description |
 |-----------|------------------------|

--- a/docs/user_guide/config_options.md
+++ b/docs/user_guide/config_options.md
@@ -54,9 +54,25 @@ modules: [
 
 ```
 
-## experiment
+## fluxsite
+Contains settings specific to fluxsite tests.
 
-: **Default:** _required key, no default_. :octicons-dash-24: Type of experiment to run. Experiments are defined in the **benchcab-evaluation** workspace on [modelevaluation.org][meorg]. This key specifies the met forcing files used in the test suite. To choose from:
+This key is _optional_. **Default** settings for the fluxsite tests will be used if it is not present
+
+```yaml
+fluxsite:
+  experiment: AU-How
+  pbs:
+    ncpus: 18
+    mem: 30GB
+    walltime: 06:00:00
+    storage: [scratch/a00, gdata/xy11]
+  multiprocess: True
+```
+
+### [experiment](#experiment)
+
+: **Default:** `forty-two-site-test`, _optional key_. :octicons-dash-24: Type of experiment to run. Experiments are defined in the **benchcab-evaluation** workspace on [modelevaluation.org][meorg]. This key specifies the met forcing files used in the test suite. To choose from:
 
 : | Key value | Experiment description |
 |-----------|------------------------|
@@ -69,24 +85,9 @@ modules: [
 | `US-Whs` | Run simulations at the Walnut Gulch Lucky Hills Shrub (US) site |
 
 ```yaml
-
-experiment: "AU-How"
-
-```
-
-## fluxsite
-Contains settings specific to fluxsite tests.
-
-This key is _optional_. **Default** settings for the fluxsite tests will be used if it is not present
-
-```yaml
 fluxsite:
-  pbs:
-    ncpus: 18
-    mem: 30GB
-    walltime: 06:00:00
-    storage: [scratch/a00, gdata/xy11]
-  multiprocess: True
+  experiment: AU-How
+
 ```
 
 ### [pbs](#pbs)


### PR DESCRIPTION
The `experiment` key in the config file is specific to fluxsite tests. This key is better placed under the `fluxsite` key as we will soon have the ability to run spatial only tests.

This change moves the `experiment` key under the `fluxsite` key and sets the experiment key to be optional.

Fixes #192