### PR TITLE
Remove absolute paths from logged standard output

### DIFF
--- a/benchcab/benchcab.py
+++ b/benchcab/benchcab.py
@@ -33,7 +33,6 @@ from benchcab.workdir import setup_fluxsite_directory_tree
 class Benchcab:
     """A class that represents the `benchcab` application."""
 
-    root_dir: Path = internal.CWD
     subprocess_handler: SubprocessWrapperInterface = SubprocessWrapper()
     modules_handler: EnvironmentModulesInterface = EnvironmentModules()
 
@@ -143,10 +142,10 @@ class Benchcab:
             msg = "Path to benchcab executable is undefined."
             raise RuntimeError(msg)
 
-        job_script_path = self.root_dir / internal.QSUB_FNAME
+        job_script_path = Path(internal.QSUB_FNAME)
         print(
             "Creating PBS job script to run fluxsite tasks on compute "
-            f"nodes: {job_script_path.relative_to(self.root_dir)}"
+            f"nodes: {job_script_path}"
         )
         with job_script_path.open("w", encoding="utf-8") as file:
             contents = render_job_script(
@@ -202,12 +201,8 @@ class Benchcab:
         )
         cable_aux_repo.checkout(verbose=verbose)
 
-        rev_number_log_path = self.root_dir / next_path(
-            self.root_dir, "rev_number-*.log"
-        )
-        print(
-            f"Writing revision number info to {rev_number_log_path.relative_to(self.root_dir)}"
-        )
+        rev_number_log_path = next_path("rev_number-*.log")
+        print(f"Writing revision number info to {rev_number_log_path}")
         with rev_number_log_path.open("w", encoding="utf-8") as file:
             file.write(rev_number_log)
 

--- a/benchcab/comparison.py
+++ b/benchcab/comparison.py
@@ -16,7 +16,6 @@ from benchcab.utils.subprocess import SubprocessWrapper, SubprocessWrapperInterf
 class ComparisonTask:
     """A class used to represent a single bitwise comparison task."""
 
-    root_dir: Path = internal.CWD
     subprocess_handler: SubprocessWrapperInterface = SubprocessWrapper()
 
     def __init__(
@@ -42,9 +41,7 @@ class ComparisonTask:
             print(f"Success: files {file_a.name} {file_b.name} are identical")
         except CalledProcessError as exc:
             output_file = (
-                self.root_dir
-                / internal.FLUXSITE_DIRS["BITWISE_CMP"]
-                / f"{self.task_name}.txt"
+                internal.FLUXSITE_DIRS["BITWISE_CMP"] / f"{self.task_name}.txt"
             )
             with output_file.open("w", encoding="utf-8") as file:
                 file.write(exc.stdout)

--- a/benchcab/internal.py
+++ b/benchcab/internal.py
@@ -61,7 +61,8 @@ CNPBIOME_FILE = (
 )
 
 # Fluxsite directory tree
-FLUXSITE_DIRS = {}
+FLUXSITE_DIRS: dict[str, Path] = {}
+
 # Relative path to root directory for CABLE fluxsite runs
 FLUXSITE_DIRS["RUN"] = RUN_DIR / "fluxsite"
 

--- a/benchcab/model.py
+++ b/benchcab/model.py
@@ -20,7 +20,6 @@ from benchcab.utils.subprocess import SubprocessWrapper, SubprocessWrapperInterf
 class Model:
     """A class used to represent a CABLE model version."""
 
-    root_dir: Path = internal.CWD
     subprocess_handler: SubprocessWrapperInterface = SubprocessWrapper()
     modules_handler: EnvironmentModulesInterface = EnvironmentModules()
 
@@ -61,19 +60,12 @@ class Model:
     def get_exe_path(self) -> Path:
         """Return the path to the built executable."""
         return (
-            self.root_dir
-            / internal.SRC_DIR
-            / self.name
-            / self.src_dir
-            / "offline"
-            / internal.CABLE_EXE
+            internal.SRC_DIR / self.name / self.src_dir / "offline" / internal.CABLE_EXE
         )
 
     def custom_build(self, modules: list[str], verbose=False):
         """Build CABLE using a custom build script."""
-        build_script_path = (
-            self.root_dir / internal.SRC_DIR / self.name / self.build_script
-        )
+        build_script_path = internal.SRC_DIR / self.name / self.build_script
 
         if not build_script_path.is_file():
             msg = (
@@ -110,50 +102,40 @@ class Model:
 
     def pre_build(self, verbose=False):
         """Runs CABLE pre-build steps."""
-        path_to_repo = self.root_dir / internal.SRC_DIR / self.name
+        path_to_repo = internal.SRC_DIR / self.name
         tmp_dir = path_to_repo / self.src_dir / "offline" / ".tmp"
         if not tmp_dir.exists():
             if verbose:
-                print(f"mkdir {tmp_dir.relative_to(self.root_dir)}")
+                print(f"mkdir {tmp_dir}")
             tmp_dir.mkdir()
 
         for pattern in internal.OFFLINE_SOURCE_FILES:
             for path in (path_to_repo / self.src_dir).glob(pattern):
                 if not path.is_file():
                     continue
-                copy2(
-                    path.relative_to(self.root_dir),
-                    tmp_dir.relative_to(self.root_dir),
-                    verbose=verbose,
-                )
+                copy2(path, tmp_dir, verbose=verbose)
 
         copy2(
-            (path_to_repo / self.src_dir / "offline" / "Makefile").relative_to(
-                self.root_dir
-            ),
-            tmp_dir.relative_to(self.root_dir),
+            path_to_repo / self.src_dir / "offline" / "Makefile",
+            tmp_dir,
             verbose=verbose,
         )
 
         copy2(
-            (path_to_repo / self.src_dir / "offline" / "parallel_cable").relative_to(
-                self.root_dir
-            ),
-            tmp_dir.relative_to(self.root_dir),
+            path_to_repo / self.src_dir / "offline" / "parallel_cable",
+            tmp_dir,
             verbose=verbose,
         )
 
         copy2(
-            (path_to_repo / self.src_dir / "offline" / "serial_cable").relative_to(
-                self.root_dir
-            ),
-            tmp_dir.relative_to(self.root_dir),
+            path_to_repo / self.src_dir / "offline" / "serial_cable",
+            tmp_dir,
             verbose=verbose,
         )
 
     def run_build(self, modules: list[str], verbose=False):
         """Runs CABLE build scripts."""
-        path_to_repo = self.root_dir / internal.SRC_DIR / self.name
+        path_to_repo = internal.SRC_DIR / self.name
         tmp_dir = path_to_repo / self.src_dir / "offline" / ".tmp"
 
         with chdir(tmp_dir), self.modules_handler.load(modules, verbose=verbose):
@@ -177,14 +159,12 @@ class Model:
 
     def post_build(self, verbose=False):
         """Runs CABLE post-build steps."""
-        path_to_repo = self.root_dir / internal.SRC_DIR / self.name
+        path_to_repo = internal.SRC_DIR / self.name
         tmp_dir = path_to_repo / self.src_dir / "offline" / ".tmp"
 
         rename(
-            (tmp_dir / internal.CABLE_EXE).relative_to(self.root_dir),
-            (path_to_repo / self.src_dir / "offline" / internal.CABLE_EXE).relative_to(
-                self.root_dir
-            ),
+            tmp_dir / internal.CABLE_EXE,
+            path_to_repo / self.src_dir / "offline" / internal.CABLE_EXE,
             verbose=verbose,
         )
 

--- a/benchcab/utils/fs.py
+++ b/benchcab/utils/fs.py
@@ -34,7 +34,7 @@ def copy2(src: Path, dest: Path, verbose=False):
     shutil.copy2(src, dest)
 
 
-def next_path(path: Path, path_pattern: str, sep: str = "-"):
+def next_path(path_pattern: str, path: Path = Path(), sep: str = "-") -> Path:
     """Finds the next free path in a sequentially named list of
     files with the following pattern in the `path` directory:
 
@@ -54,7 +54,7 @@ def next_path(path: Path, path_pattern: str, sep: str = "-"):
         common_filename, last_file_index = pattern_files_sorted[-1].stem.split(sep)
         new_file_index = int(last_file_index) + 1
 
-    return f"{common_filename}{sep}{new_file_index}{loc_pattern.suffix}"
+    return Path(f"{common_filename}{sep}{new_file_index}{loc_pattern.suffix}")
 
 
 def mkdir(new_path: Path, verbose=False, **kwargs):

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -25,18 +25,17 @@ def files():
 
 
 @pytest.fixture()
-def comparison_task(files, mock_cwd, mock_subprocess_handler):
+def comparison_task(files, mock_subprocess_handler):
     """Returns a mock `ComparisonTask` instance for testing against."""
     _comparison_task = ComparisonTask(files=files, task_name=TASK_NAME)
     _comparison_task.subprocess_handler = mock_subprocess_handler
-    _comparison_task.root_dir = mock_cwd
     return _comparison_task
 
 
 class TestRun:
     """Tests for `ComparisonTask.run()`."""
 
-    @pytest.fixture()
+    @pytest.fixture(autouse=True)
     def bitwise_cmp_dir(self):
         """Create and return the fluxsite bitwise comparison directory."""
         internal.FLUXSITE_DIRS["BITWISE_CMP"].mkdir(parents=True)
@@ -78,11 +77,6 @@ class TestRun:
         with stdout_file.open("r", encoding="utf-8") as file:
             assert file.read() == mock_subprocess_handler.stdout
 
-    # TODO(Sean) fix for issue https://github.com/CABLE-LSM/benchcab/issues/162
-    @pytest.mark.skip(
-        reason="""This will always fail since `parametrize()` parameters are
-        dependent on the `mock_cwd` fixture."""
-    )
     @pytest.mark.parametrize(
         ("verbosity", "expected"),
         [
@@ -90,14 +84,14 @@ class TestRun:
                 False,
                 f"Failure: files {FILE_NAME_A} {FILE_NAME_B} differ. Results of "
                 "diff have been written to "
-                f"{internal.FLUXSITE_DIRS['BITWISE_CMP']}/{TASK_NAME}\n",
+                f"{internal.FLUXSITE_DIRS['BITWISE_CMP']}/{TASK_NAME}.txt\n",
             ),
             (
                 True,
                 f"Comparing files {FILE_NAME_A} and {FILE_NAME_B} bitwise...\n"
                 f"Failure: files {FILE_NAME_A} {FILE_NAME_B} differ. Results of "
                 "diff have been written to "
-                f"{internal.FLUXSITE_DIRS['BITWISE_CMP']}/{TASK_NAME}\n",
+                f"{internal.FLUXSITE_DIRS['BITWISE_CMP']}/{TASK_NAME}.txt\n",
             ),
         ],
     )

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -22,14 +22,14 @@ class TestNextPath:
         """Return a file pattern for testing against."""
         return "rev_number-*.log"
 
-    def test_next_path_in_empty_cwd(self, pattern, mock_cwd):
-        """Success case: get next path in 'empty' CWD."""
-        assert next_path(mock_cwd, pattern) == "rev_number-1.log"
+    def test_next_path_in_empty_cwd(self, pattern):
+        """Success case: get next path in 'empty' directory."""
+        assert next_path(pattern) == Path("rev_number-1.log")
 
-    def test_next_path_in_non_empty_cwd(self, pattern, mock_cwd):
-        """Success case: get next path in 'non-empty' CWD."""
-        (mock_cwd / next_path(mock_cwd, pattern)).touch()
-        assert next_path(mock_cwd, pattern) == "rev_number-2.log"
+    def test_next_path_in_non_empty_cwd(self, pattern):
+        """Success case: get next path in 'non-empty' directory."""
+        next_path(pattern).touch()
+        assert next_path(pattern) == Path("rev_number-2.log")
 
 
 class TestMkdir:


### PR DESCRIPTION
This change forces paths to be relative to the CWD throughout the code base unless absolute paths are required.

Improves code readability and cleaner logging to standard output.

Fixes #162