### PR TITLE
Include README contents in index.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 [![Documentation status][readthedocs_badge]][docs] [![Test coverage][codecov_badge]][codecov_summary] [![Conda package status][conda_badge]][conda] [![GitHub License][license_badge]][license]
 
-
+<!-- --8<-- [start:contents] -->
 `benchcab` is a testing framework that tests the CABLE land surface model across a range of model configurations and model versions. The tool:
+
 - checks out the model versions specified by the user
 - builds the required executables
 - runs each model version across N standard science configurations
@@ -13,9 +14,13 @@ The user can then pipe the model outputs into a benchmark analysis via [modeleva
 
 The full documentation is available at [benchcab.readthedocs.io][docs].
 
+## License
+
+`benchcab` is distributed under [an Apache License v2.0][apache-license].
+
 ## Acknowledgements
 
-- `benchcab` is a continuation of the efforts made by Martin De Kauwe ([@mdekauwe](https://github.com/mdekauwe)) and Gab Abramowitz ([@gabsun](https://github.com/gabsun)) in developing a CABLE benchmarking framework - we thank them for their contribution.
+`benchcab` is a continuation of the efforts made by Martin De Kauwe ([@mdekauwe](https://github.com/mdekauwe)) and Gab Abramowitz ([@gabsun](https://github.com/gabsun)) in developing a CABLE benchmarking framework - we thank them for their contribution.
 
 [conda_badge]: https://img.shields.io/conda/v/accessnri/benchcab
 [codecov_badge]: https://codecov.io/gh/CABLE-LSM/benchcab/branch/main/graph/badge.svg?token=JJYE1YZDXQ
@@ -26,3 +31,5 @@ The full documentation is available at [benchcab.readthedocs.io][docs].
 [docs]: https://benchcab.readthedocs.io
 [license]: https://github.com/CABLE-LSM/benchcab/blob/main/LICENSE
 [meorg]: https://modelevaluation.org
+[apache-license]: https://www.apache.org/licenses/LICENSE-2.0
+<!-- --8<-- [end:contents] -->

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,15 +1,3 @@
 # About benchcab
 
-`benchcab` is an evaluation tool for the land surface model CABLE. `benchcab` is designed to perform set standard simulations with two versions of CABLE. These simulations are then analysed together in modelevaluation.org to assess the scientific strengths and gaps in the two CABLE versions.
-
-It is developed and maintained by the CABLE's user community and the ACCESS-NRI.
-
-## License
-
-`benchcab` is distributed under [an Apache License v2.0][apache-license].
-
-## Acknowledgements
-
-`benchcab` is a continuation of the efforts made by Martin De Kauwe ([@mdekauwe](https://github.com/mdekauwe)) and Gab Abramowitz ([@gabsun](https://github.com/gabsun)) in developing a CABLE benchmarking framework - we thank them for their contribution.
-
-[apache-license]: https://www.apache.org/licenses/LICENSE-2.0
+--8<-- "README.md:contents"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ markdown_extensions:
   - pymdownx.emoji:
       emoji_index: !!python/name:materialx.emoji.twemoji
       emoji_generator: !!python/name:materialx.emoji.to_svg
+  - pymdownx.snippets
 
 
 extra_javascript:


### PR DESCRIPTION
Content is duplicated across `docs/index.md` and `README.md`. This change merges the two pages and embeds the README contents in index.md.

Fixes #218