### PR TITLE
Deprecate serial_cable and parallel_cable scripts

### DIFF
--- a/benchcab/data/test/integration.sh
+++ b/benchcab/data/test/integration.sh
@@ -21,6 +21,10 @@ realisations:
   - repo:
       svn:
         branch_path: trunk
+    # TODO(Sean): This is required to compile legacy versions.
+    # We should probably deprecate support for SVN branches
+    # and remove the SVN trunk from our integration tests.
+    build_script: offline/build3.sh
   - repo:
       git:
         branch: main

--- a/benchcab/model.py
+++ b/benchcab/model.py
@@ -121,18 +121,6 @@ class Model:
             verbose=verbose,
         )
 
-        copy2(
-            path_to_repo / self.src_dir / "offline" / "parallel_cable",
-            tmp_dir,
-            verbose=verbose,
-        )
-
-        copy2(
-            path_to_repo / self.src_dir / "offline" / "serial_cable",
-            tmp_dir,
-            verbose=verbose,
-        )
-
     def run_build(self, modules: list[str], verbose=False):
         """Runs CABLE build scripts."""
         path_to_repo = internal.SRC_DIR / self.name
@@ -148,13 +136,7 @@ class Model:
             env["FC"] = "mpif90" if internal.MPI else "ifort"
 
             self.subprocess_handler.run_cmd(
-                "make -f Makefile", env=env, verbose=verbose
-            )
-            self.subprocess_handler.run_cmd(
-                f"./{'parallel_cable' if internal.MPI else 'serial_cable'} \"{env['FC']}\" "
-                f"\"{env['CFLAGS']}\" \"{env['LDFLAGS']}\" \"{env['LD']}\" \"{env['NCMOD']}\"",
-                env=env,
-                verbose=verbose,
+                "make mpi" if internal.MPI else "make", env=env, verbose=verbose
             )
 
     def post_build(self, verbose=False):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -140,8 +140,6 @@ class TestPreBuild:
         """Setup precondition for `Model.pre_build()`."""
         (internal.SRC_DIR / model.name / "offline").mkdir(parents=True)
         (internal.SRC_DIR / model.name / "offline" / "Makefile").touch()
-        (internal.SRC_DIR / model.name / "offline" / "parallel_cable").touch()
-        (internal.SRC_DIR / model.name / "offline" / "serial_cable").touch()
         (internal.SRC_DIR / model.name / "offline" / "foo.f90").touch()
 
     def test_source_files_and_scripts_are_copied_to_tmp_dir(self, model):
@@ -149,8 +147,6 @@ class TestPreBuild:
         model.pre_build()
         tmp_dir = internal.SRC_DIR / model.name / "offline" / ".tmp"
         assert (tmp_dir / "Makefile").exists()
-        assert (tmp_dir / "parallel_cable").exists()
-        assert (tmp_dir / "serial_cable").exists()
         assert (tmp_dir / "foo.f90").exists()
 
 
@@ -184,21 +180,14 @@ class TestRunBuild:
         """Setup precondition for `Model.run_build()`."""
         (internal.SRC_DIR / model.name / "offline" / ".tmp").mkdir(parents=True)
 
-        # This is required so that we can use the NETCDF_ROOT environment variable
-        # when running `make`, and `serial_cable` and `parallel_cable` scripts:
+        # This is required so that we can use the NETCDF_ROOT environment
+        # variable when running `make`:
         os.environ["NETCDF_ROOT"] = netcdf_root
 
-    def test_build_command_execution(
-        self, model, mock_subprocess_handler, modules, netcdf_root
-    ):
+    def test_build_command_execution(self, model, mock_subprocess_handler, modules):
         """Success case: test build commands are run."""
         model.run_build(modules)
-        assert mock_subprocess_handler.commands == [
-            "make -f Makefile",
-            './serial_cable "ifort" "-O2 -fp-model precise"'
-            f' "-L{netcdf_root}/lib/Intel -O0" "-lnetcdf -lnetcdff" '
-            f'"{netcdf_root}/include/Intel"',
-        ]
+        assert mock_subprocess_handler.commands == ["make"]
 
     def test_modules_loaded_at_runtime(
         self, model, mock_environment_modules_handler, modules


### PR DESCRIPTION
The `serial_cable` and `parallel_cable` scripts were deprecated in https://github.com/CABLE-LSM/CABLE/pull/193. This change does the same in the benchcab source code.

Code branches that require the serial_cable and parallel_cable scripts can use the `build_script` key as a work around.

Fixes #223