### PR TITLE
Deprecate PBR build dependency

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -19,7 +19,6 @@ requirements:
     host:
         - python >=3.9
         - pip
-        - pbr
     run:
         - python >=3.9
         - netCDF4

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,10 +12,7 @@ classifier=
     Operating System :: POSIX :: Linux
     Programming Language :: Python :: 3.9
 
-[files]
-packages = benchcab
-
-[entry_points]
+[options.entry_points]
 console_scripts = 
     benchcab=benchcab.main:main
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,4 @@
 
 from setuptools import setup
 
-setup(
-    setup_requires=['setuptools', 'pbr'],
-    pbr=True,
-)
+setup()


### PR DESCRIPTION
[PBR](https://docs.openstack.org/pbr/latest/index.html) is removed from the build dependencies so that we can use [versioneer](https://github.com/python-versioneer/python-versioneer) to solve #129. This change removes the [additional options provided by PBR in setup.cfg](https://docs.openstack.org/pbr/latest/user/using.html#setup-cfg) or replaces these options with [the default options that come with setuptools](https://setuptools.pypa.io/en/latest/userguide/declarative_config.html).

Fixes #227