### PR TITLE
`project` keyword improvements in `config.yml`

### DIFF
--- a/benchcab/benchcab.py
+++ b/benchcab/benchcab.py
@@ -133,6 +133,7 @@ class Benchcab:
     ) -> None:
         """Submits the PBS job script step in the fluxsite test workflow."""
         config = self._get_config(config_path)
+
         self._validate_environment(project=config["project"], modules=config["modules"])
         if self.benchcab_exe_path is None:
             msg = "Path to benchcab executable is undefined."

--- a/benchcab/benchcab.py
+++ b/benchcab/benchcab.py
@@ -133,7 +133,6 @@ class Benchcab:
     ) -> None:
         """Submits the PBS job script step in the fluxsite test workflow."""
         config = self._get_config(config_path)
-
         self._validate_environment(project=config["project"], modules=config["modules"])
         if self.benchcab_exe_path is None:
             msg = "Path to benchcab executable is undefined."

--- a/benchcab/benchcab.py
+++ b/benchcab/benchcab.py
@@ -64,15 +64,21 @@ class Benchcab:
             )
             sys.exit(1)
 
-        required_groups = [project, "ks32", "hh5"]
+        if project is None:
+            msg = """Couldn't resolve project: check 'project' in config.yaml
+                and/or $PROJECT set in ~/.config/gadi-login.conf
+                """
+            raise AttributeError(msg)
+
+        required_groups = set([project, "ks32", "hh5"])
         groups = [grp.getgrgid(gid).gr_name for gid in os.getgroups()]
-        if not set(required_groups).issubset(groups):
-            print(
-                "Error: user does not have the required group permissions.",
-                "The required groups are:",
-                ", ".join(required_groups),
+        if not required_groups.issubset(groups):
+            msg = (
+                f"""Error: user does not have the required group permissions.,
+                The required groups are:,
+                {", ".join(required_groups)}""",
             )
-            sys.exit(1)
+            raise PermissionError(msg)
 
         for modname in modules:
             if not self.modules_handler.module_is_avail(modname):

--- a/benchcab/config.py
+++ b/benchcab/config.py
@@ -91,6 +91,17 @@ def read_optional_key(config: dict):
             raise ValueError(msg)
         config["project"] = os.environ["PROJECT"]
 
+    # Directory List is obtained from Gadi Resources - https://opus.nci.org.au/display/Help/0.+Welcome+to+Gadi
+    data_dirs = ["/g/data", "/scratch"]
+    groups = list(
+        set([group for data_dir in data_dirs for group in os.listdir(data_dir)])
+    )
+
+    if config["project"] not in groups:
+        msg = f"User is not a member of project [{config['project']}]: Check if project key is correct"
+
+        raise ValueError(msg)
+
     if "realisations" in config:
         for r in config["realisations"]:
             r["name"] = r.get("name")
@@ -152,8 +163,8 @@ def read_config(config_path: str) -> dict:
     """
     # Read configuration file
     config = read_config_file(config_path)
-    # Populate configuration dict with optional keys
-    read_optional_key(config)
     # Validate and return.
     validate_config(config)
+    # Populate configuration dict with optional keys
+    read_optional_key(config)
     return config

--- a/benchcab/config.py
+++ b/benchcab/config.py
@@ -83,27 +83,7 @@ def read_optional_key(config: dict):
         The configuration file with with/without optional keys
     """
     if "project" not in config:
-        if "PROJECT" not in os.environ:
-            msg = """Couldn't resolve project: check 'project' in config.yaml
-                and/or $PROJECT set in ~/.config/gadi-login.conf
-                """
-            raise ValueError(msg)
-        config["project"] = os.environ["PROJECT"]
-
-    groups = list(
-        set(
-            [
-                group
-                for data_dir in internal.USER_PROJECT_DIRS
-                for group in os.listdir(data_dir)
-            ]
-        )
-    )
-
-    if config["project"] not in groups:
-        msg = f"User is not a member of project [{config['project']}]: Check if project key is correct"
-
-        raise ValueError(msg)
+        config["project"] = os.environ.get("PROJECT", None)
 
     if "realisations" in config:
         for r in config["realisations"]:
@@ -166,8 +146,8 @@ def read_config(config_path: str) -> dict:
     """
     # Read configuration file
     config = read_config_file(config_path)
-    # Validate and return.
-    validate_config(config)
     # Populate configuration dict with optional keys
     read_optional_key(config)
+    # Validate and return.
+    validate_config(config)
     return config

--- a/benchcab/config.py
+++ b/benchcab/config.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """A module containing all *_config() functions."""
+import os
+import sys
 from pathlib import Path
 
 import yaml
@@ -81,6 +83,14 @@ def read_optional_key(config: dict):
     config : dict
         The configuration file with with/without optional keys
     """
+    if "project" not in config:
+        if "PROJECT" not in os.environ:
+            msg = """Couldn't resolve project: check 'project' in config.yaml
+                and/or $PROJECT set in ~/.config/gadi-login.conf
+                """
+            raise ValueError(msg)
+        config["project"] = os.environ["PROJECT"]
+
     if "realisations" in config:
         for r in config["realisations"]:
             r["name"] = r.get("name")

--- a/benchcab/config.py
+++ b/benchcab/config.py
@@ -3,7 +3,6 @@
 
 """A module containing all *_config() functions."""
 import os
-import sys
 from pathlib import Path
 
 import yaml
@@ -91,10 +90,14 @@ def read_optional_key(config: dict):
             raise ValueError(msg)
         config["project"] = os.environ["PROJECT"]
 
-    # Directory List is obtained from Gadi Resources - https://opus.nci.org.au/display/Help/0.+Welcome+to+Gadi
-    data_dirs = ["/g/data", "/scratch"]
     groups = list(
-        set([group for data_dir in data_dirs for group in os.listdir(data_dir)])
+        set(
+            [
+                group
+                for data_dir in internal.USER_PROJECT_DIRS
+                for group in os.listdir(data_dir)
+            ]
+        )
     )
 
     if config["project"] not in groups:

--- a/benchcab/data/config-schema.yml
+++ b/benchcab/data/config-schema.yml
@@ -1,5 +1,6 @@
 project:
   type: "string"
+  required: false
 
 modules:
   type: "list"

--- a/benchcab/data/test/config-basic.yml
+++ b/benchcab/data/test/config-basic.yml
@@ -15,7 +15,7 @@
 #
 # Strings can be given with or without double or single quotes.
 
-project: w97
+# Uses minimal set of parameters required to run benchcab
 
 realisations:
   - repo:

--- a/benchcab/data/test/config-invalid.yml
+++ b/benchcab/data/test/config-invalid.yml
@@ -1,5 +1,4 @@
 # A sample configuration that should fail validation.
-project: w97
 
 fluxsite:
   experiment:  NON EXISTENT EXPERIMENT!!!

--- a/benchcab/data/test/config-optional.yml
+++ b/benchcab/data/test/config-optional.yml
@@ -1,0 +1,35 @@
+# Config with optional data
+project: optional
+
+fluxsite:
+  experiment: AU-Tum
+  multiprocess: False
+  pbs:
+    ncpus: 6
+    mem: 10GB
+    walltime: "10:00:00"
+    storage:
+      - scratch/$PROJECT
+
+science_configurations:
+  - cable:
+      cable_user: 
+        GS_SWITCH: "test_gs"
+        FWSOIL_SWITCH: "test_fw"
+
+realisations:
+  - repo:
+      svn:
+        branch_path: trunk
+    name: svn_trunk
+  - repo:
+      svn:
+        branch_path: branches/Users/ccc561/v3.0-YP-changes
+    name: git_branch
+
+
+modules: [
+  intel-compiler/2021.1.1,
+  netcdf/4.7.4,
+  openmpi/4.1.0
+]

--- a/benchcab/data/test/config-optional.yml
+++ b/benchcab/data/test/config-optional.yml
@@ -1,5 +1,5 @@
 # Config with optional data
-project: optional
+project: hh5 
 
 fluxsite:
   experiment: AU-Tum

--- a/benchcab/internal.py
+++ b/benchcab/internal.py
@@ -28,10 +28,6 @@ FLUXSITE_DEFAULT_MULTIPROCESS = True
 # Path to the user's current working directory
 CWD = Path.cwd()
 
-# Directory List is obtained from Gadi User Guide in Section - Gadi Resources
-# https://opus.nci.org.au/display/Help/0.+Welcome+to+Gadi
-USER_PROJECT_DIRS = ["/g/data", "/scratch"]
-
 # Path to the user's home directory
 HOME_DIR = Path(os.environ["HOME"])
 

--- a/benchcab/internal.py
+++ b/benchcab/internal.py
@@ -10,7 +10,7 @@ from benchcab.utils.pbs import PBSConfig
 
 _, NODENAME, _, _, _ = os.uname()
 
-CONFIG_REQUIRED_KEYS = ["realisations", "project", "modules", "experiment"]
+CONFIG_REQUIRED_KEYS = ["realisations", "modules", "experiment"]
 
 # Parameters for job script:
 QSUB_FNAME = "benchmark_cable_qsub.sh"

--- a/benchcab/internal.py
+++ b/benchcab/internal.py
@@ -10,7 +10,7 @@ from benchcab.utils.pbs import PBSConfig
 
 _, NODENAME, _, _, _ = os.uname()
 
-CONFIG_REQUIRED_KEYS = ["realisations", "modules", "experiment"]
+CONFIG_REQUIRED_KEYS = ["realisations", "modules"]
 
 # Parameters for job script:
 QSUB_FNAME = "benchmark_cable_qsub.sh"
@@ -27,6 +27,10 @@ FLUXSITE_DEFAULT_MULTIPROCESS = True
 
 # Path to the user's current working directory
 CWD = Path.cwd()
+
+# Directory List is obtained from Gadi User Guide in Section - Gadi Resources
+# https://opus.nci.org.au/display/Help/0.+Welcome+to+Gadi
+USER_PROJECT_DIRS = ["/g/data", "/scratch"]
 
 # Path to the user's home directory
 HOME_DIR = Path(os.environ["HOME"])

--- a/docs/user_guide/config_options.md
+++ b/docs/user_guide/config_options.md
@@ -32,8 +32,7 @@ The different running modes of `benchcab` are solely dependent on the options us
 
 ## project
 
-NCI project ID to charge the simulations to.
-This key is _optional_. If ID is not provided, the current workspace project - i.e. the environment variable `$PROJECT` will be used.
+: **Default:** user's default project, _optional key_. :octicons-dash-24: NCI project ID to charge the simulations to. The user's default project defined in the $PROJECT environment variable is used by default.
 
 ``` yaml
 

--- a/docs/user_guide/config_options.md
+++ b/docs/user_guide/config_options.md
@@ -32,7 +32,8 @@ The different running modes of `benchcab` are solely dependent on the options us
 
 ## project
 
-: **Default:** _required key, no default_. :octicons-dash-24: NCI project ID to charge the simulations to.
+NCI project ID to charge the simulations to.
+This key is _optional_. If ID is not provided, the current workspace project - i.e. the environment variable `$PROJECT` will be used.
 
 ``` yaml
 

--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -20,7 +20,7 @@ To use `benchcab`, you need to join the following projects at NCI:
 
 - [ks32][ks32_mynci]
 - [hh5][hh5_mynci]
-- [wd9][wd9_mynci] if not part of the [cable][cable_mynci]
+- [wd9][wd9_mynci] if not part of the [cable][cable_mynci] project
 
 ## Installation
 

--- a/tests/test_benchcab.py
+++ b/tests/test_benchcab.py
@@ -1,0 +1,67 @@
+"""`pytest` tests for `benchcab.py`."""
+import re
+from contextlib import nullcontext as does_not_raise
+from unittest import mock
+
+import pytest
+
+from benchcab.benchcab import Benchcab
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _set_user_projects():
+    with mock.patch("grp.getgrgid") as mocked_getgrid, mock.patch(
+        "os.getgroups"
+    ) as mocked_groups:
+        type(mocked_getgrid.return_value).gr_name = mock.PropertyMock(
+            return_value="hh5"
+        )
+        mocked_groups.return_value = [1]
+        yield
+
+
+@pytest.fixture(scope="module", params=["hh5", "invalid_project_name"])
+def config_project(request):
+    """Get config project name."""
+    return request.param
+
+
+# Error message if config project name cannot be resolved.
+no_project_name_msg = re.escape(
+    """Couldn't resolve project: check 'project' in config.yaml
+       and/or $PROJECT set in ~/.config/gadi-login.conf
+    """
+)
+
+# For testing whether user is member of necessary projects to run benchcab, we need to simulate the environment of Gadi
+# TODO: Simulate Gadi environment for running tests for validating environment
+
+
+@pytest.mark.skip()
+@pytest.mark.parametrize(
+    ("config_project", "pytest_error"),
+    [
+        ("hh5", does_not_raise()),
+        (None, pytest.raises(AttributeError, match=no_project_name_msg)),
+    ],
+)
+def test_project_name(config_project, pytest_error):
+    """Tests whether config project name is suitable to run in Gadi environment."""
+    app = Benchcab(benchcab_exe_path=None)
+    with pytest_error:
+        app._validate_environment(project=config_project, modules=[])
+
+
+@pytest.mark.skip()
+@pytest.mark.parametrize(
+    ("config_project", "pytest_error"),
+    [
+        ("hh5", does_not_raise()),
+        ("invalid_project_name", pytest.raises(PermissionError)),
+    ],
+)
+def test_user_project_group(config_project, pytest_error):
+    """Test _validate_environment for if current user's groups does not contain the project name."""
+    app = Benchcab(benchcab_exe_path=None)
+    with pytest_error:
+        app._validate_environment(project=config_project, modules=[])


### PR DESCRIPTION
Fixes #231 , #246

**Merge Message**

- In case the user provides the `project` keyword, use the corresponding value as ID, otherwise use `$PROJECT`.
- Added skippable tests for validating against existing project groups. 
- Modularized test cases for `config` module.

