### PR TITLE
Remove svn dependency in default runs

### DIFF
--- a/benchcab/benchcab.py
+++ b/benchcab/benchcab.py
@@ -193,14 +193,6 @@ class Benchcab:
             model.repo.checkout(verbose=verbose)
             rev_number_log += f"{model.name}: {model.repo.get_revision()}\n"
 
-        # TODO(Sean) we should archive revision numbers for CABLE-AUX
-        cable_aux_repo = SVNRepo(
-            svn_root=internal.CABLE_SVN_ROOT,
-            branch_path=internal.CABLE_AUX_RELATIVE_SVN_PATH,
-            path=internal.SRC_DIR / "CABLE-AUX",
-        )
-        cable_aux_repo.checkout(verbose=verbose)
-
         rev_number_log_path = next_path("rev_number-*.log")
         print(f"Writing revision number info to {rev_number_log_path}")
         with rev_number_log_path.open("w", encoding="utf-8") as file:

--- a/benchcab/data/test/integration.sh
+++ b/benchcab/data/test/integration.sh
@@ -32,7 +32,7 @@ fluxsite:
   experiment: AU-Tum
   pbs:
     storage:
-      - gdata/rp23
+      - gdata/wd9
       - scratch/$PROJECT
 EOL
 

--- a/benchcab/data/test/integration.sh
+++ b/benchcab/data/test/integration.sh
@@ -19,13 +19,6 @@ project: $PROJECT
 
 realisations:
   - repo:
-      svn:
-        branch_path: trunk
-    # TODO(Sean): This is required to compile legacy versions.
-    # We should probably deprecate support for SVN branches
-    # and remove the SVN trunk from our integration tests.
-    build_script: offline/build3.sh
-  - repo:
       git:
         branch: main
 

--- a/benchcab/data/test/integration.sh
+++ b/benchcab/data/test/integration.sh
@@ -32,7 +32,6 @@ fluxsite:
   experiment: AU-Tum
   pbs:
     storage:
-      - gdata/wd9
       - scratch/$PROJECT
 EOL
 

--- a/benchcab/data/test/integration.sh
+++ b/benchcab/data/test/integration.sh
@@ -32,6 +32,7 @@ fluxsite:
   experiment: AU-Tum
   pbs:
     storage:
+      - gdata/rp23
       - scratch/$PROJECT
 EOL
 

--- a/benchcab/fluxsite.py
+++ b/benchcab/fluxsite.py
@@ -175,10 +175,6 @@ class Task:
                         "restart": False,
                     },
                     "fixedCO2": internal.CABLE_FIXED_CO2_CONC,
-                    "casafile": {
-                        "phen": str(internal.PHEN_FILE.absolute()),
-                        "cnpbiome": str(internal.CNPBIOME_FILE.absolute()),
-                    },
                     "spinup": False,
                 }
             },

--- a/benchcab/internal.py
+++ b/benchcab/internal.py
@@ -39,11 +39,11 @@ RUN_DIR = Path("runs")
 # Relative path to core namelist files
 NAMELIST_DIR = Path("namelists")
 
-# Path to grid files
-GRID_DIR = Path("/g/data/rp23/data/no_provenance/gridinfo")
+# Path to CABLE-AUX
+CABLE_AUX_DIR = Path("/g/data/wd9/BenchMarking/CABLE-AUX_v20240122")
 
 # Path CABLE grid info file
-GRID_FILE = GRID_DIR / "crujra_accessN96_gridinfo.nc"
+GRID_FILE = CABLE_AUX_DIR / "offline" / "gridinfo_CSIRO_1x1.nc"
 
 # Fluxsite directory tree
 FLUXSITE_DIRS: dict[str, Path] = {}

--- a/benchcab/internal.py
+++ b/benchcab/internal.py
@@ -39,26 +39,11 @@ RUN_DIR = Path("runs")
 # Relative path to core namelist files
 NAMELIST_DIR = Path("namelists")
 
-# Relative path to CABLE Auxiliary repository
-CABLE_AUX_DIR = SRC_DIR / "CABLE-AUX"
+# Path to grid files
+GRID_DIR = Path("/g/data/rp23/data/no_provenance/gridinfo")
 
-# Relative URL path to CABLE Auxiliary repository on SVN
-CABLE_AUX_RELATIVE_SVN_PATH = "branches/Share/CABLE-AUX"
-
-# TODO(Sean): hard coding paths assets in CABLE_AUX is brittle, these should
-# be promoted to config parameters, especially since we no longer throw exceptions
-# when the assets cannot be found.
-
-# Relative path to CABLE grid info file
-GRID_FILE = CABLE_AUX_DIR / "offline" / "gridinfo_CSIRO_1x1.nc"
-
-# Relative path to modis_phenology_csiro.txt
-PHEN_FILE = CABLE_AUX_DIR / "core" / "biogeochem" / "modis_phenology_csiro.txt"
-
-# Relative path to pftlookup_csiro_v16_17tiles.csv
-CNPBIOME_FILE = (
-    CABLE_AUX_DIR / "core" / "biogeochem" / "pftlookup_csiro_v16_17tiles.csv"
-)
+# Path CABLE grid info file
+GRID_FILE = GRID_DIR / "crujra_accessN96_gridinfo.nc"
 
 # Fluxsite directory tree
 FLUXSITE_DIRS: dict[str, Path] = {}

--- a/benchcab/utils/pbs.py
+++ b/benchcab/utils/pbs.py
@@ -35,6 +35,7 @@ def render_job_script(
     storage_flags = [
         "gdata/ks32",
         "gdata/hh5",
+        "gdata/wd9", # Subgroup of gdata/ks32
         *pbs_config.get("storage", internal.FLUXSITE_DEFAULT_PBS["storage"]),
     ]
     return f"""#!/bin/bash

--- a/tests/test_fluxsite.py
+++ b/tests/test_fluxsite.py
@@ -277,10 +277,6 @@ class TestSetupTask:
             },
             "output": {"restart": False},
             "fixedco2": internal.CABLE_FIXED_CO2_CONC,
-            "casafile": {
-                "phen": str(internal.PHEN_FILE.absolute()),
-                "cnpbiome": str(internal.CNPBIOME_FILE.absolute()),
-            },
             "spinup": False,
             "some_setting": True,
             "some_branch_specific_setting": True,

--- a/tests/test_pbs.py
+++ b/tests/test_pbs.py
@@ -24,7 +24,7 @@ class TestRenderJobScript:
 #PBS -P tm70
 #PBS -j oe
 #PBS -m e
-#PBS -l storage=gdata/ks32+gdata/hh5
+#PBS -l storage=gdata/ks32+gdata/hh5+gdata/wd9
 
 module purge
 module load foo
@@ -58,7 +58,7 @@ set -ev
 #PBS -P tm70
 #PBS -j oe
 #PBS -m e
-#PBS -l storage=gdata/ks32+gdata/hh5
+#PBS -l storage=gdata/ks32+gdata/hh5+gdata/wd9
 
 module purge
 module load foo
@@ -92,7 +92,7 @@ set -ev
 #PBS -P tm70
 #PBS -j oe
 #PBS -m e
-#PBS -l storage=gdata/ks32+gdata/hh5
+#PBS -l storage=gdata/ks32+gdata/hh5+gdata/wd9
 
 module purge
 module load foo
@@ -130,7 +130,7 @@ set -ev
 #PBS -P tm70
 #PBS -j oe
 #PBS -m e
-#PBS -l storage=gdata/ks32+gdata/hh5+gdata/foo
+#PBS -l storage=gdata/ks32+gdata/hh5+gdata/wd9+gdata/foo
 
 module purge
 module load foo
@@ -163,7 +163,7 @@ set -ev
 #PBS -P tm70
 #PBS -j oe
 #PBS -m e
-#PBS -l storage=gdata/ks32+gdata/hh5
+#PBS -l storage=gdata/ks32+gdata/hh5+gdata/wd9
 
 module purge
 module load foo


### PR DESCRIPTION
Fixes #230 

**Merge Message**
When running benchcab, it checks out on svn branch, potentially for data files like `GRID_DATA`. This commit:
- Removes the dependency to check out in svn branch
- Cleans up internal variables for unused files
- Uses alternative sources for existing data files in svn - testing was done via bitwise comparison generated by `main` vs `230-remove-svn-dependency` branch during integration tests

