### PR TITLE
Disable module load, unload, ... invocations via wrapper

### DIFF
--- a/docs/user_guide/config_options.md
+++ b/docs/user_guide/config_options.md
@@ -388,7 +388,7 @@ realisations:
 
 ### [build_script](#build_script)
 
-: **Default:** unset, _optional key_. :octicons-dash-24: The path to a custom shell script to build the code in that branch, relative to the repository root directory. **Note:** any lines in the provided shell script that call the [environment modules API][environment-modules] will be ignored. To specify modules to use for the build script, please specify them using the [`modules`](#modules) key.
+: **Default:** unset, _optional key_. :octicons-dash-24: The path to a custom shell script to build the code in that branch, relative to the repository root directory. **Note:** invocations of the [`module`][environment-modules] command which modify the user environment (i.e. `add`, `load`, `rm`, `unload`, `purge`, ...) will be ignored. To specify modules to use for the build script, please specify them using the [`modules`](#modules) key.
 
 ```yaml
 realisations:

--- a/src/benchcab/data/environment_modules_wrapper.bash
+++ b/src/benchcab/data/environment_modules_wrapper.bash
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Wrapper around the module (environment modules) command which disables
+# commands that modify the current environment.
+module() {
+    args=("$@")
+    for arg in "${args[@]}"; do
+        case $arg in
+            add|load|rm|unload|swap|switch|use|unuse|purge)
+                echo "command disabled: module ""${args[*]}" 1>&2
+                return 1
+                ;;
+        esac
+    done
+    _module_raw "${args[@]}" 2>&1
+    return $?
+}

--- a/src/benchcab/utils/__init__.py
+++ b/src/benchcab/utils/__init__.py
@@ -32,6 +32,23 @@ def get_installed_root() -> Path:
     return Path(resources.files("benchcab"))
 
 
+def get_package_data_path(resource: Path) -> Path:
+    """Return the absolute path to a given resource in the package data directory.
+
+    Parameters
+    ----------
+    resource: Path
+        Path to the resource relative to the package data directory.
+
+    Returns
+    -------
+    Path
+        Absolute path to the resource.
+
+    """
+    return Path(sys.modules["benchcab"].__file__).parent / "data" / resource
+
+
 def load_package_data(filename: str) -> Union[str, dict]:
     """Load data out of the installed package data directory.
 


### PR DESCRIPTION
This change disables module commands that modify the environment via a wrapper when running a custom build script. This avoids preprocessing the custom build script for module statements which may produce an invalid bash script. This also allows for module commands that do not alter the environment to be executed as we only disable a subset of subcommands in the wrapper.

Fixes #249