### PR TITLE
Set minimum payu version to 1.0.30

### DIFF
--- a/.conda/benchcab-dev.yaml
+++ b/.conda/benchcab-dev.yaml
@@ -7,7 +7,7 @@ channels:
 
 dependencies:
   - python=3.9
-  - payu
+  - payu>=1.0.30
   - pip
   - f90nml
   - netcdf4

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -21,6 +21,7 @@ requirements:
         - pip
     run:
         - python >=3.9
+        - payu >=1.0.30
         - netCDF4
         - PyYAML
         - f90nml


### PR DESCRIPTION
Set minimum payu version to [1.0.30 (CABLE model driver support)](https://github.com/payu-org/payu/releases/tag/1.0.30).

Fixes #261