### PR TITLE
Run pytest using local conda installation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,33 +15,25 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          # Fetch all history for all tags and branches (tag information is
+          # required when building the conda package)
+          fetch-depth: 0
       - uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: '3.9'
-          auto-activate-base: false
-          activate-environment: benchcab-dev
-          environment-file: .conda/benchcab-dev.yaml
+      - name: Build and install conda package
+        run: |
+          conda install conda-build
+          conda build -c conda-forge -c accessnri -c coecms .
+          conda install --no-channel-priority -c $CONDA_PREFIX/conda-bld -c conda-forge -c accessnri -c coecms benchcab
+          conda uninstall conda-build
       - name: Test with pytest
         run: |
+          conda install pytest-cov
           pytest --cov=./ --cov-report=xml
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
-  
-  build_conda_package:
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          python-version: '3.9'
-      - name: Test conda build
-        run: |
-          conda install conda-build
-          conda build -c conda-forge -c accessnri -c coecms .


### PR DESCRIPTION
This change improves the CI to detect missing dependencies in meta.yaml by running pytest with the dependencies that come installed with a local benchcab install.

This PR should go in after #266 so we can verify the CI is working as intended.

Fixes #264