### PR TITLE
Add install_dir option

### DIFF
--- a/benchcab/data/config-schema.yml
+++ b/benchcab/data/config-schema.yml
@@ -58,6 +58,9 @@ realisations:
       build_script:
         type: "string"
         required: false
+      install_dir:
+        type: "string"
+        required: false
       patch:
         type: "dict"
         required: false

--- a/benchcab/model.py
+++ b/benchcab/model.py
@@ -31,6 +31,7 @@ class Model:
         patch: Optional[dict] = None,
         patch_remove: Optional[dict] = None,
         build_script: Optional[str] = None,
+        install_dir: Optional[str] = None,
         model_id: Optional[int] = None,
     ) -> None:
         """Constructor.
@@ -47,6 +48,9 @@ class Model:
             Patch remove, by default None
         build_script : Optional[str], optional
             Build script, by default None
+        install_dir : Optional[str], optional
+            Path to installed executables relative to the project root directory
+            of the CABLE repository, by default None.
         model_id : Optional[int], optional
             Model ID, by default None
 
@@ -56,6 +60,7 @@ class Model:
         self.patch = patch
         self.patch_remove = patch_remove
         self.build_script = build_script
+        self.install_dir = install_dir
         self._model_id = model_id
         self.src_dir = Path()
         self.logger = get_logger()
@@ -79,13 +84,10 @@ class Model:
 
     def get_exe_path(self, mpi=False) -> Path:
         """Return the path to the built executable."""
-        return (
-            internal.SRC_DIR
-            / self.name
-            / self.src_dir
-            / "offline"
-            / (internal.CABLE_MPI_EXE if mpi else internal.CABLE_EXE)
-        )
+        exe = internal.CABLE_MPI_EXE if mpi else internal.CABLE_EXE
+        if self.install_dir:
+            return internal.SRC_DIR / self.name / self.install_dir / exe
+        return internal.SRC_DIR / self.name / self.src_dir / "offline" / exe
 
     def custom_build(self, modules: list[str]):
         """Build CABLE using a custom build script."""

--- a/docs/user_guide/config_options.md
+++ b/docs/user_guide/config_options.md
@@ -399,6 +399,18 @@ realisations:
     build_script: offline/build.sh
 ```
 
+### [install_dir](#install-dir)
+
+: **Default:** unset, _optional key_. :octicons-dash-24: The path to the directory containing the installed executables relative to the project root directory of the CABLE repository. If specified, `benchcab` will look for executables in this directory when building up the run directories.
+
+```yaml
+realisations:
+  - repo:
+      git:
+        branch: my_branch
+    install_dir: path/to/bin/directory
+```
+
 ### [patch](#patch)
 
 : **Default:** unset, _optional key_. :octicons-dash-24: Branch-specific namelist settings for `cable.nml`. Settings specified in `patch` get "patched" to the base namelist settings used for both branches. Any namelist settings specified here will overwrite settings defined in the default namelist file and in the science configurations. This means these settings will be set as stipulated in the `patch` for this branch for all science configurations run by `benchcab`.


### PR DESCRIPTION
Currently benchcab assumes the compiled executables are installed under the src/offline directory, however this may not always be the case (e.g. [this script](https://github.com/CABLE-LSM/CABLE/blob/main/build.bash) installs binaries under `<project_root>/bin`). This change adds the `install_dir` option which lets the user specify the directory in which benchcab can find the built executables.

Fixes #259