### PR TITLE
Use package_data configuration option

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,8 +18,10 @@ console_scripts =
 [tool:pytest]
 addopts = --doctest-modules --doctest-glob='*.rst' --ignore setup.py --ignore conftest.py --ignore docs/conf.py
 
-[options]
-include_package_data = True
+[options.package_data]
+benchcab =
+    data/*
+    data/test/*
 
 [versioneer]
 VCS = git


### PR DESCRIPTION
Currently the uploaded tarball for benchcab v4.0.0 is missing the site-packages/benchcab/data directory (see https://anaconda.org/accessnri/benchcab/files). This change fixes this by replacing the `include_package_data` option with the `package_data` option in setup.cfg (see [Data Files Support](https://setuptools.pypa.io/en/latest/userguide/datafiles.html)).

Conda package deployment was tested [here](https://github.com/SeanBryan51/benchcab/actions/runs/8353675085/job/22865775572) in a forked repository and the uploaded tarball contains the package data directory.

Fixes #267