### PR TITLE
Update to CMake build

### DIFF
--- a/docs/user_guide/running_CABLE_v2.md
+++ b/docs/user_guide/running_CABLE_v2.md
@@ -41,6 +41,7 @@ There are two differences one might need to deal with to run with an older versi
 
 - ensure your build script is using exactly the same modules as listed in the [`config.yaml` file](config_options.md#modules) of the `benchcab` work directory. For this you can either modify the modules in your build script or in the `config.yaml` file. Make sure to commit the build script with the correct modules to your branch before running `benchcab`.
 - give the path to the build script for that older branch using the [`build_script` option](config_options.md#build_script) in the `config.yaml` file.
+- give the path to the install directory of built executables using the [`install_dir` option](config_options.md#install_dir) in the `config.yaml`.
 
 ## FLUXNET data
 

--- a/src/benchcab/benchcab.py
+++ b/src/benchcab/benchcab.py
@@ -255,13 +255,11 @@ class Benchcab:
                 repo.custom_build(modules=config["modules"])
 
             else:
-                build_mode = "with MPI" if mpi else "serially"
+                build_mode = "serial and MPI" if mpi else "serial"
                 self.logger.info(
                     f"Compiling CABLE {build_mode} for realisation {repo.name}..."
                 )
-                repo.pre_build(mpi=mpi)
-                repo.run_build(modules=config["modules"], mpi=mpi)
-                repo.post_build(mpi=mpi)
+                repo.build(modules=config["modules"], mpi=mpi)
             self.logger.info(f"Successfully compiled CABLE for realisation {repo.name}")
 
     def fluxsite_setup_work_directory(self, config_path: str):
@@ -366,7 +364,6 @@ class Benchcab:
     def run(self, config_path: str, skip: list[str]):
         """Endpoint for `benchcab run`."""
         self.checkout(config_path)
-        self.build(config_path)
         self.build(config_path, mpi=True)
         self.fluxsite_setup_work_directory(config_path)
         self.spatial_setup_work_directory(config_path)

--- a/src/benchcab/data/test/integration.sh
+++ b/src/benchcab/data/test/integration.sh
@@ -18,8 +18,6 @@ mkdir -p $TEST_DIR
 # Clone local checkout for CABLE
 git clone $CABLE_REPO $CABLE_DIR
 cd $CABLE_DIR
-# Note: This is temporary, to be removed once #258 is fixed
-git reset --hard 67a52dc5721f0da78ee7d61798c0e8a804dcaaeb
 
 # Clone the example repo
 git clone $EXAMPLE_REPO $TEST_DIR
@@ -36,7 +34,6 @@ realisations:
   - repo:
       git:
         branch: main
-        commit: 67a52dc5721f0da78ee7d61798c0e8a804dcaaeb  # Note: This is temporary, to be removed once #258 is fixed
 modules: [
   intel-compiler/2021.1.1,
   netcdf/4.7.4,

--- a/src/benchcab/internal.py
+++ b/src/benchcab/internal.py
@@ -12,6 +12,12 @@ _, NODENAME, _, _, _ = os.uname()
 
 CONFIG_REQUIRED_KEYS = ["realisations", "modules"]
 
+# CMake module used for compilation:
+CMAKE_MODULE = "cmake/3.24.2"
+
+# Number of parallel jobs used when compiling with CMake:
+CMAKE_BUILD_PARALLEL_LEVEL = 4
+
 # Parameters for job script:
 QSUB_FNAME = "benchmark_cable_qsub.sh"
 FLUXSITE_DEFAULT_PBS: PBSConfig = {

--- a/src/benchcab/utils/fs.py
+++ b/src/benchcab/utils/fs.py
@@ -72,3 +72,19 @@ def mkdir(new_path: Path, **kwargs):
     """
     get_logger().debug(f"Creating {new_path} directory")
     new_path.mkdir(**kwargs)
+
+
+def prepend_path(var: str, path: str, env=os.environ):
+    """Prepend path to environment variable.
+
+    Parameters
+    ----------
+    var : str
+        Name of environment variable.
+    path : str
+        Path to prepend.
+    env : dict
+        Environment dictionary.
+
+    """
+    env[var] = os.pathsep.join(filter(None, [path, env.get(var)]))

--- a/tests/test_fluxsite.py
+++ b/tests/test_fluxsite.py
@@ -10,7 +10,6 @@ import math
 import f90nml
 import netCDF4
 import pytest
-
 from benchcab import __version__, internal
 from benchcab.fluxsite import (
     CableError,
@@ -107,7 +106,7 @@ class TestFetchFiles:
         (internal.FLUXSITE_DIRS["OUTPUT"]).mkdir(parents=True)
         (internal.FLUXSITE_DIRS["LOG"]).mkdir(parents=True)
 
-        exe_build_dir = internal.SRC_DIR / "test-branch" / "offline"
+        exe_build_dir = internal.SRC_DIR / "test-branch" / "bin"
         exe_build_dir.mkdir(parents=True)
         (exe_build_dir / internal.CABLE_EXE).touch()
 
@@ -170,7 +169,7 @@ class TestSetupTask:
         (internal.FLUXSITE_DIRS["OUTPUT"]).mkdir(parents=True)
         (internal.FLUXSITE_DIRS["LOG"]).mkdir(parents=True)
 
-        exe_build_dir = internal.SRC_DIR / "test-branch" / "offline"
+        exe_build_dir = internal.SRC_DIR / "test-branch" / "bin"
         exe_build_dir.mkdir(parents=True)
         (exe_build_dir / internal.CABLE_EXE).touch()
 

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -6,11 +6,11 @@ pytest autouse fixture.
 """
 
 import logging
+import os
 from pathlib import Path
 
 import pytest
-
-from benchcab.utils.fs import chdir, mkdir, next_path
+from benchcab.utils.fs import chdir, mkdir, next_path, prepend_path
 
 
 class TestNextPath:
@@ -68,3 +68,25 @@ class TestMkdir:
         mkdir(test_path, **kwargs)
         assert test_path.exists()
         test_path.rmdir()
+
+
+class TestPrependPath:
+    """Tests for `prepend_path()`."""
+
+    var = "PATHS"
+    new_path = "/path/to/bar"
+
+    @pytest.mark.parametrize(
+        ("env", "expected"),
+        [
+            ({}, new_path),
+            (
+                {var: "/path/to/foo"},
+                f"{new_path}{os.pathsep}/path/to/foo",
+            ),
+        ],
+    )
+    def test_prepend_path(self, env, expected):
+        """Success case: test prepend_path for unset and existing variables."""
+        prepend_path(self.var, self.new_path, env=env)
+        assert env[self.var] == expected

--- a/tests/test_spatial.py
+++ b/tests/test_spatial.py
@@ -5,19 +5,14 @@ the working directory used for testing is cleaned up in the `_run_around_tests`
 pytest autouse fixture.
 """
 
-import contextlib
-import io
 import logging
-from pathlib import Path
 
 import f90nml
 import pytest
 import yaml
-
 from benchcab import internal
 from benchcab.model import Model
 from benchcab.spatial import SpatialTask, get_spatial_tasks
-from benchcab.utils import get_logger
 from benchcab.utils.repo import Repo
 
 
@@ -92,7 +87,7 @@ class TestConfigureExperiment:
             config = yaml.safe_load(file)
         assert config["exe"] == str(
             (
-                internal.SRC_DIR / "test-branch" / "offline" / internal.CABLE_MPI_EXE
+                internal.SRC_DIR / "test-branch" / "bin" / internal.CABLE_MPI_EXE
             ).absolute()
         )
         assert config["laboratory"] == str(internal.PAYU_LABORATORY_DIR.absolute())


### PR DESCRIPTION
The CABLE build system was transitioned from Makefile to CMake: see https://github.com/CABLE-LSM/CABLE/pull/216, https://github.com/CABLE-LSM/CABLE/pull/200. This change adds support for building CABLE via CMake in benchcab so that CABLE versions which branch from the HEAD of main can be tested.

Closes #258