### PR TITLE
Unset LDFLAGS and CMAKE_PREFIX_PATH variables

### DIFF
--- a/src/benchcab/model.py
+++ b/src/benchcab/model.py
@@ -129,6 +129,15 @@ class Model:
             [internal.CMAKE_MODULE, *modules]
         ):
             env = os.environ.copy()
+
+            # This is required to prevent CMake from finding the conda
+            # installation of netcdf-fortran (#279):
+            env.pop("LDFLAGS", None)
+
+            # This is required to prevent CMake from finding MPI libraries in
+            # the conda environment (#279):
+            env.pop("CMAKE_PREFIX_PATH", None)
+
             # This is required so that the netcdf-fortran library is discoverable by
             # pkg-config:
             prepend_path(


### PR DESCRIPTION
CABLE is linked against incorrect libraries for netcdf and MPI when running benchcab (v4.0.2) from the hh5 conda environment. The issue is due to environment variables being set which affect the behaviour of the build, notably LDFLAGS and CMAKE_PREFIX_PATH, which point CMake to find the netcdf and MPI libraries installed in the current conda environment. This change unsets these variables so that CMake finds the appropriate libraries which get loaded in as modules.

Fixes #279