### PR TITLE
Check if repository_path is already initialized

### DIFF
--- a/src/benchcab/utils/repo.py
+++ b/src/benchcab/utils/repo.py
@@ -137,8 +137,11 @@ class GitRepo(Repo):
         """
         self.url = url
         self.branch = branch
+        is_bare_directory = realisation_path.is_dir() and (
+            not (realisation_path / ".git").exists()
+        )
         self.realisation_path = (
-            realisation_path / branch if realisation_path.is_dir() else realisation_path
+            realisation_path / branch if is_bare_directory else realisation_path
         )
         self.commit = commit
         self.logger = get_logger()
@@ -223,9 +226,12 @@ class SVNRepo(Repo):
         self.svn_root = svn_root
         self.branch_path = branch_path
         self.revision = revision
+        is_bare_directory = realisation_path.is_dir() and (
+            not (realisation_path / ".svn").exists()
+        )
         self.realisation_path = (
             realisation_path / Path(branch_path).name
-            if realisation_path.is_dir()
+            if is_bare_directory
             else realisation_path
         )
         self.logger = get_logger()


### PR DESCRIPTION
Currently, the `GitRepo` and `SVNRepo` objects incorrectly modify the path to the source repository if the path points to a directory initialised by either `git` or `svn`. This change adds checks on the repository path so that the correct behaviour applies in this case.

Fixes #243 