### PR TITLE
Log status of fluxsite and comparison runs

### DIFF
--- a/src/benchcab/fluxsite.py
+++ b/src/benchcab/fluxsite.py
@@ -239,7 +239,7 @@ class FluxsiteTask:
                     output_file=stdout_path.relative_to(task_dir),
                 )
         except CalledProcessError as exc:
-            self.logger.debug(f"Error: CABLE returned an error for task {task_name}")
+            self.logger.error(f"Error: CABLE returned an error for task {task_name}")
             raise CableError from exc
 
     def add_provenance_info(self):

--- a/src/benchcab/fluxsite.py
+++ b/src/benchcab/fluxsite.py
@@ -19,6 +19,7 @@ from benchcab.model import Model
 from benchcab.utils import get_logger
 from benchcab.utils.fs import chdir, mkdir
 from benchcab.utils.namelist import patch_namelist, patch_remove_namelist
+from benchcab.utils.state import State
 from benchcab.utils.subprocess import SubprocessWrapper, SubprocessWrapperInterface
 
 f90_logical_repr = {True: ".true.", False: ".false."}
@@ -59,6 +60,13 @@ class FluxsiteTask:
         self.sci_conf_id = sci_conf_id
         self.sci_config = sci_config
         self.logger = get_logger()
+        self.state = State(
+            state_dir=internal.STATE_DIR / "fluxsite" / "runs" / self.get_task_name()
+        )
+
+    def is_done(self) -> bool:
+        """Return status of current task."""
+        return self.state.is_set("done")
 
     def get_task_name(self) -> str:
         """Returns the file name convention used for this task."""
@@ -150,7 +158,7 @@ class FluxsiteTask:
             patch_remove_namelist(nml_path, self.model.patch_remove)
 
     def clean_task(self):
-        """Cleans output files, namelist files, log files and cable executables if they exist."""
+        """Cleans output files, namelist files, log files and cable executables if they exist and resets the task state."""
         self.logger.debug("  Cleaning task")
 
         task_dir = internal.FLUXSITE_DIRS["TASKS"] / self.get_task_name()
@@ -178,6 +186,8 @@ class FluxsiteTask:
         log_file = internal.FLUXSITE_DIRS["LOG"] / self.get_log_filename()
         if log_file.exists():
             log_file.unlink()
+
+        self.state.reset()
 
         return self
 
@@ -215,6 +225,7 @@ class FluxsiteTask:
         try:
             self.run_cable()
             self.add_provenance_info()
+            self.state.set("done")
         except CableError:
             # Note: here we suppress CABLE specific errors so that `benchcab`
             # exits successfully. This then allows us to run bitwise comparisons

--- a/src/benchcab/internal.py
+++ b/src/benchcab/internal.py
@@ -30,6 +30,10 @@ FLUXSITE_DEFAULT_MULTIPROCESS = True
 
 # DIRECTORY PATHS/STRUCTURE:
 
+# Path to hidden state directory:
+STATE_DIR = Path(".state")
+STATE_PREFIX = ".state_attr_"
+
 # Default system paths in Unix
 SYSTEM_PATHS = ["/bin", "/usr/bin", "/usr/local/bin"]
 

--- a/src/benchcab/utils/state.py
+++ b/src/benchcab/utils/state.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+from benchcab.internal import STATE_PREFIX
+
+
+class StateAttributeError(Exception):
+    """Exception class for signalling state attribute errors."""
+
+
+class State:
+    """Stores state which persists on the file system."""
+
+    def __init__(self, state_dir: Path) -> None:
+        """Instantiate a State object.
+
+        Parameters
+        ----------
+        state_dir: Path
+            Path to the directory in which state is stored. If the specified
+            directory does not exist, create the directory.
+
+        """
+        self.state_dir = state_dir
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+
+    def reset(self):
+        """Clear all state attributes."""
+        for path in self.state_dir.glob(f"{STATE_PREFIX}*"):
+            path.unlink()
+
+    def set(self, attr: str):
+        """Set state attribute."""
+        (self.state_dir / (STATE_PREFIX + attr)).touch()
+
+    def is_set(self, attr: str):
+        """Return True if the state attribute has been set, False otherwise."""
+        return (self.state_dir / (STATE_PREFIX + attr)).exists()
+
+    def get(self) -> str:
+        """Get the state of the most recent state attribute."""
+        attrs = list(self.state_dir.glob(f"{STATE_PREFIX}*"))
+
+        def get_mtime(path: Path):
+            return path.stat().st_mtime
+
+        attrs.sort(key=get_mtime)
+        try:
+            return attrs.pop().name.removeprefix(STATE_PREFIX)
+        except IndexError as exc:
+            msg = "No attributes have been set."
+            raise StateAttributeError(msg) from exc

--- a/src/benchcab/workdir.py
+++ b/src/benchcab/workdir.py
@@ -24,6 +24,9 @@ def clean_submission_files():
     if internal.RUN_DIR.exists():
         shutil.rmtree(internal.RUN_DIR)
 
+    if internal.STATE_DIR.exists():
+        shutil.rmtree(internal.STATE_DIR)
+
     for pbs_job_file in Path.cwd().glob(f"{internal.QSUB_FNAME}*"):
         pbs_job_file.unlink()
 

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -8,7 +8,6 @@ pytest autouse fixture.
 from pathlib import Path
 
 import pytest
-
 from benchcab import internal
 from benchcab.comparison import ComparisonTask
 
@@ -30,20 +29,44 @@ def comparison_task(files, mock_subprocess_handler):
     return _comparison_task
 
 
-class TestRun:
-    """Tests for `ComparisonTask.run()`."""
+@pytest.fixture(autouse=True)
+def bitwise_cmp_dir():
+    """Create and return the fluxsite bitwise comparison directory."""
+    internal.FLUXSITE_DIRS["BITWISE_CMP"].mkdir(parents=True)
+    return internal.FLUXSITE_DIRS["BITWISE_CMP"]
 
-    @pytest.fixture(autouse=True)
-    def bitwise_cmp_dir(self):
-        """Create and return the fluxsite bitwise comparison directory."""
-        internal.FLUXSITE_DIRS["BITWISE_CMP"].mkdir(parents=True)
-        return internal.FLUXSITE_DIRS["BITWISE_CMP"]
+
+class TestClean:
+    """Tests for `ComparisonTask.clean()`."""
+
+    def test_error_logs_are_removed(self, comparison_task):
+        """Success case: test error logs are removed."""
+        output_file = comparison_task.output_file
+        output_file.touch()
+        comparison_task.clean()
+        assert not output_file.exists()
+
+    def test_task_state_is_reset(self, comparison_task):
+        """Success case: test task state is reset."""
+        state = comparison_task.state
+        state.set("dirty")
+        comparison_task.clean()
+        assert not state.is_set("dirty")
+
+
+class TestExecuteComparison:
+    """Tests for `ComparisonTask.execute_comparison()`."""
 
     def test_nccmp_execution(self, comparison_task, files, mock_subprocess_handler):
         """Success case: test nccmp is executed."""
         file_a, file_b = files
-        comparison_task.run()
+        comparison_task.execute_comparison()
         assert f"nccmp -df {file_a} {file_b}" in mock_subprocess_handler.commands
+
+    def test_task_is_done_on_success(self, comparison_task):
+        """Success case: test task is done on success."""
+        comparison_task.execute_comparison()
+        assert comparison_task.is_done()
 
     def test_failed_comparison_check(
         self, comparison_task, mock_subprocess_handler, bitwise_cmp_dir

--- a/tests/test_fluxsite.py
+++ b/tests/test_fluxsite.py
@@ -152,6 +152,13 @@ class TestCleanTask:
         ).exists()
         assert not (internal.FLUXSITE_DIRS["LOG"] / task.get_log_filename()).exists()
 
+    def test_state_is_reset(self, task):
+        """Success case: test state is reset on clean."""
+        state = task.state
+        state.set("foo")
+        task.clean_task()
+        assert not state.is_set("foo")
+
 
 class TestSetupTask:
     """Tests for `FluxsiteTask.setup_task()`."""

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,39 @@
+import time
+from pathlib import Path
+
+import pytest
+from benchcab.utils.state import State, StateAttributeError
+
+
+@pytest.fixture()
+def state():
+    """Return a State object."""
+    return State(state_dir=Path("my_state"))
+
+
+def test_state_is_set(state):
+    """Success case: test state is set."""
+    state.set("foo")
+    assert state.is_set("foo")
+
+
+def test_state_reset(state):
+    """Success case: test state is reset."""
+    state.set("foo")
+    state.reset()
+    assert not state.is_set("foo")
+
+
+def test_state_get(state):
+    """Success case: test get() returns the most recent state attribute."""
+    state.set("foo")
+    # This is done so that time stamps can be resolved between state attributes
+    time.sleep(0.01)
+    state.set("bar")
+    assert state.get() == "bar"
+
+
+def test_state_get_raises_exception(state):
+    """Failure case: test get() raises an exception when no attributes are set."""
+    with pytest.raises(StateAttributeError):
+        state.get()

--- a/tests/test_workdir.py
+++ b/tests/test_workdir.py
@@ -87,6 +87,13 @@ class TestCleanFiles:
         return runs_path
 
     @pytest.fixture()
+    def state_path(self) -> Path:
+        """Mock internal.STATE_DIR."""
+        state_path = Path(".state")
+        state_path.mkdir()
+        return state_path
+
+    @pytest.fixture()
     def pbs_job_files(self) -> List[Path]:
         """Create sample files of the form benchmark_cable_qsub.sh*."""
         pbs_job_files = [
@@ -133,8 +140,11 @@ class TestCleanFiles:
         clean_realisation_files()
         assert not src_path_with_git.exists()
 
-    def test_clean_submission_files(self, runs_path, pbs_job_files: List[Path]):
+    def test_clean_submission_files(
+        self, runs_path, state_path, pbs_job_files: List[Path]
+    ):
         """Success case: Submission files created by benchcab are removed after clean."""
         clean_submission_files()
         assert not runs_path.exists()
+        assert not state_path.exists()
         assert not self._check_if_any_files_exist(pbs_job_files)


### PR DESCRIPTION
This change improves how the exit status of fluxsite tasks and bitwise comparison tasks are reported in the PBS log files so that users know which tasks succeeded/failed.

A `State` object is introduced as a minimal way of having state persist between separate processes. This is necessary for correctly showing the status of fluxsite and comparison runs as these tasks are run inside child processes which do not share the same data structures in the parent process.

Fixes #180