### PR TITLE
Build MPI and serial executables in separate build trees

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -121,7 +121,6 @@ class TestGetBuildFlags:
 
         return {
             "build_type": codecov_build_type[codecov],
-            "mpi": mpi_args[mpi],
             "flags_init": codecov_init_args[codecov],
         }
 
@@ -136,11 +135,11 @@ class TestGetBuildFlags:
                 User has {compiler_id} in their environment"""
                 ),
             ):
-                model._get_build_flags(mpi, codecov, compiler_id)
+                model._get_build_flags(codecov, compiler_id)
             return
 
         # Success case: get expected build flags to pass to CMake.
-        assert model._get_build_flags(mpi, codecov, compiler_id) == cmake_flags
+        assert model._get_build_flags(codecov, compiler_id) == cmake_flags
 
 
 # TODO(Sean) remove for issue https://github.com/CABLE-LSM/benchcab/issues/211


### PR DESCRIPTION
Benchcab currently fails to install the executables for https://github.com/CABLE-LSM/CABLE/pull/469 due to a change in the structure of the CMakeLists.txt file - namely a single executable is now only built per build tree where as before both serial and MPI executables were built under the same build tree. Whilst this was convenient, it breaks the CMake model of one build configuration per build tree (see PR for more details) and will be hard to maintain with MPI development going forward.

This change adds support for the changes to CMakeLists.txt as part of https://github.com/CABLE-LSM/CABLE/pull/469 by generating two out of source builds for serial and MPI applications instead of one. This change is also backwards compatible for CABLE commits prior to the changes to CMakeLists.txt.