### PR TITLE
Updated minimum meorg_client version required. Fixes #321

### DIFF
--- a/.conda/benchcab-dev.yaml
+++ b/.conda/benchcab-dev.yaml
@@ -17,7 +17,7 @@ dependencies:
   - gitpython
   - jinja2
   - hpcpy>=0.5.0
-  - meorg_client
+  - meorg_client>=0.3.1
   # CI
   - pytest-cov
   # Dev Dependencies

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -30,4 +30,4 @@ requirements:
         - gitpython
         - jinja2
         - hpcpy>=0.5.0
-        - meorg_client
+        - meorg_client>=0.3.1


### PR DESCRIPTION
Minimum required version for `meorg_client` to get access to recent updates.