### PR TITLE
Remove module load/purge statements from PBS job

### DIFF
--- a/src/benchcab/benchcab.py
+++ b/src/benchcab/benchcab.py
@@ -216,7 +216,6 @@ class Benchcab:
             contents = render_job_script(
                 project=config["project"],
                 config_path=config_path,
-                modules=config["modules"],
                 pbs_config=config["fluxsite"]["pbs"],
                 skip_bitwise_cmp="fluxsite-bitwise-cmp" in skip,
                 skip_codecov="gen_codecov" in skip or not config["codecov"],

--- a/src/benchcab/data/pbs_jobscript.j2
+++ b/src/benchcab/data/pbs_jobscript.j2
@@ -9,10 +9,6 @@
 #PBS -m e
 #PBS -l storage={{storage}}
 
-module purge
-{% for module in modules -%}
-module load {{module}}
-{% endfor %}
 set -ev
 
 {{benchcab_path}} fluxsite-run-tasks --config={{config_path}}{{verbose_flag}}

--- a/src/benchcab/data/test/pbs_jobscript_default.sh
+++ b/src/benchcab/data/test/pbs_jobscript_default.sh
@@ -9,11 +9,6 @@
 #PBS -m e
 #PBS -l storage=gdata/ks32+gdata/hh5+gdata/wd9
 
-module purge
-module load foo
-module load bar
-module load baz
-
 set -ev
 
 /absolute/path/to/benchcab fluxsite-run-tasks --config=/path/to/config.yaml

--- a/src/benchcab/data/test/pbs_jobscript_no_skip_codecov.sh
+++ b/src/benchcab/data/test/pbs_jobscript_no_skip_codecov.sh
@@ -9,11 +9,6 @@
 #PBS -m e
 #PBS -l storage=gdata/ks32+gdata/hh5+gdata/wd9
 
-module purge
-module load foo
-module load bar
-module load baz
-
 set -ev
 
 /absolute/path/to/benchcab fluxsite-run-tasks --config=/path/to/config.yaml

--- a/src/benchcab/data/test/pbs_jobscript_skip_optional.sh
+++ b/src/benchcab/data/test/pbs_jobscript_skip_optional.sh
@@ -9,11 +9,6 @@
 #PBS -m e
 #PBS -l storage=gdata/ks32+gdata/hh5+gdata/wd9
 
-module purge
-module load foo
-module load bar
-module load baz
-
 set -ev
 
 /absolute/path/to/benchcab fluxsite-run-tasks --config=/path/to/config.yaml

--- a/src/benchcab/data/test/pbs_jobscript_verbose.sh
+++ b/src/benchcab/data/test/pbs_jobscript_verbose.sh
@@ -9,11 +9,6 @@
 #PBS -m e
 #PBS -l storage=gdata/ks32+gdata/hh5+gdata/wd9
 
-module purge
-module load foo
-module load bar
-module load baz
-
 set -ev
 
 /absolute/path/to/benchcab fluxsite-run-tasks --config=/path/to/config.yaml -v

--- a/src/benchcab/utils/pbs.py
+++ b/src/benchcab/utils/pbs.py
@@ -20,7 +20,6 @@ class PBSConfig(TypedDict):
 def render_job_script(
     project: str,
     config_path: str,
-    modules: list,
     benchcab_path: str,
     pbs_config: PBSConfig,
     verbose: Optional[bool] = False,
@@ -36,7 +35,6 @@ def render_job_script(
     storage_flags = ["gdata/ks32", "gdata/hh5", "gdata/wd9", *pbs_config["storage"]]
 
     context = dict(
-        modules=modules,
         verbose_flag=verbose_flag,
         ncpus=pbs_config["ncpus"],
         mem=pbs_config["mem"],

--- a/tests/test_pbs.py
+++ b/tests/test_pbs.py
@@ -13,7 +13,6 @@ class TestRenderJobScript:
         assert render_job_script(
             project="tm70",
             config_path="/path/to/config.yaml",
-            modules=["foo", "bar", "baz"],
             pbs_config=internal.FLUXSITE_DEFAULT_PBS,
             benchcab_path="/absolute/path/to/benchcab",
         ) == load_package_data("test/pbs_jobscript_default.sh")
@@ -23,7 +22,6 @@ class TestRenderJobScript:
         assert render_job_script(
             project="tm70",
             config_path="/path/to/config.yaml",
-            modules=["foo", "bar", "baz"],
             pbs_config=internal.FLUXSITE_DEFAULT_PBS,
             verbose=True,
             benchcab_path="/absolute/path/to/benchcab",
@@ -34,7 +32,6 @@ class TestRenderJobScript:
         assert render_job_script(
             project="tm70",
             config_path="/path/to/config.yaml",
-            modules=["foo", "bar", "baz"],
             pbs_config=internal.FLUXSITE_DEFAULT_PBS,
             skip_bitwise_cmp=True,
             benchcab_path="/absolute/path/to/benchcab",
@@ -45,7 +42,6 @@ class TestRenderJobScript:
         assert render_job_script(
             project="tm70",
             config_path="/path/to/config.yaml",
-            modules=["foo", "bar", "baz"],
             pbs_config=internal.FLUXSITE_DEFAULT_PBS,
             skip_codecov=False,
             benchcab_path="/absolute/path/to/benchcab",


### PR DESCRIPTION
Loading modules prior to launching benchcab may break the environment (as evident in #329 for the xp65 container environments).

Modules do not actually need to be loaded when running CABLE as CMake sets the RPATH on the executable to point to all the library dependencies, so it is safe to remove these module statements from the job script.

Fixes #329