### PR TITLE
`xp65` release changes

### DIFF
--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -13,7 +13,7 @@ In this guide, we will describe:
 To use `benchcab`, you need to join the following projects at NCI:
 
 - [ks32][ks32_mynci]
-- [hh5][hh5_mynci]
+- [xp65][xp65_mynci]
 - [wd9][wd9_mynci] if not part of the [cable][cable_mynci] project
 
 ## Quick-start
@@ -21,8 +21,8 @@ To use `benchcab`, you need to join the following projects at NCI:
 To launch a `benchcab` run, execute the following in the command line:
 
 ```sh
-module use /g/data/hh5/public/modules
-module load conda/analysis3-unstable
+module use /g/data/xp65/public/modules
+module load conda/benchcab
 cd /scratch/$PROJECT/$USER
 git clone https://github.com/CABLE-LSM/bench_example.git
 cd bench_example
@@ -33,18 +33,18 @@ benchcab run
 
 ## Installation
 
-The package is already installed for you in the Conda environments under the hh5 project. You simply need to load the module for the conda environment:
+The package is already installed for you in the Conda environments under the xp65 project. You simply need to load the module for the conda environment:
 
 ```bash
-   module use /g/data/hh5/public/modules
-   module load conda/analysis3-unstable
+   module use /g/data/xp65/public/modules
+   module load conda/benchcab
 ```
 
 You need to load the module on each new session at NCI on login or compute nodes.
 
 !!! Tip "Save the module location"
 
-    You should not put any `module load` or `module add` commands in your `$HOME/.bashrc` file. But you can safely store the `module use /g/data/hh5/public/modules` command in your `$HOME/.bashrc` file. This means you won't have to type this line again in other sessions you open on Gadi.
+    You should not put any `module load` or `module add` commands in your `$HOME/.bashrc` file. But you can safely store the `module use /g/data/xp65/public/modules` command in your `$HOME/.bashrc` file. This means you won't have to type this line again in other sessions you open on Gadi.
 
 ## Usage
 
@@ -306,7 +306,7 @@ Please enter your questions as issues on [the benchcab repository][issues-benchc
 
 Alternatively, you can also access the ACCESS-NRI User support via [the ACCESS-Hive forum][forum-support].
 
-[hh5_mynci]: https://my.nci.org.au/mancini/project/hh5
+[xp65_mynci]: https://my.nci.org.au/mancini/project/xp65
 [ks32_mynci]: https://my.nci.org.au/mancini/project/ks32
 [wd9_mynci]: https://my.nci.org.au/mancini/project/wd9
 [cable_mynci]: https://my.nci.org.au/mancini/project/cable

--- a/src/benchcab/benchcab.py
+++ b/src/benchcab/benchcab.py
@@ -107,7 +107,7 @@ class Benchcab:
                 """
             raise AttributeError(msg)
 
-        required_groups = set([project, "ks32", "hh5"])
+        required_groups = set([project, "ks32", "xp65"])
         groups = [grp.getgrgid(gid).gr_name for gid in os.getgroups()]
         if not required_groups.issubset(groups):
             msg = (

--- a/src/benchcab/data/test/config-optional.yml
+++ b/src/benchcab/data/test/config-optional.yml
@@ -1,5 +1,5 @@
 # Config with optional data
-project: hh5 
+project: xp65
 
 fluxsite:
   experiment: AU-Tum

--- a/src/benchcab/data/test/pbs_jobscript_default.sh
+++ b/src/benchcab/data/test/pbs_jobscript_default.sh
@@ -7,7 +7,7 @@
 #PBS -P tm70
 #PBS -j oe
 #PBS -m e
-#PBS -l storage=gdata/ks32+gdata/hh5+gdata/wd9
+#PBS -l storage=gdata/ks32+gdata/xp65+gdata/wd9
 
 set -ev
 

--- a/src/benchcab/data/test/pbs_jobscript_no_skip_codecov.sh
+++ b/src/benchcab/data/test/pbs_jobscript_no_skip_codecov.sh
@@ -7,7 +7,7 @@
 #PBS -P tm70
 #PBS -j oe
 #PBS -m e
-#PBS -l storage=gdata/ks32+gdata/hh5+gdata/wd9
+#PBS -l storage=gdata/ks32+gdata/xp65+gdata/wd9
 
 set -ev
 

--- a/src/benchcab/data/test/pbs_jobscript_skip_optional.sh
+++ b/src/benchcab/data/test/pbs_jobscript_skip_optional.sh
@@ -7,7 +7,7 @@
 #PBS -P tm70
 #PBS -j oe
 #PBS -m e
-#PBS -l storage=gdata/ks32+gdata/hh5+gdata/wd9
+#PBS -l storage=gdata/ks32+gdata/xp65+gdata/wd9
 
 set -ev
 

--- a/src/benchcab/data/test/pbs_jobscript_verbose.sh
+++ b/src/benchcab/data/test/pbs_jobscript_verbose.sh
@@ -7,7 +7,7 @@
 #PBS -P tm70
 #PBS -j oe
 #PBS -m e
-#PBS -l storage=gdata/ks32+gdata/hh5+gdata/wd9
+#PBS -l storage=gdata/ks32+gdata/xp65+gdata/wd9
 
 set -ev
 

--- a/src/benchcab/internal.py
+++ b/src/benchcab/internal.py
@@ -283,5 +283,5 @@ MEORG_CLIENT = dict(
     cache_delay=60 * 5,  # 5mins between upload and analysis triggering
     mem="8G",
     walltime="01:00:00",
-    storage=["gdata/ks32", "gdata/hh5", "gdata/wd9", "gdata/rp23"],
+    storage=["gdata/ks32", "gdata/xp65", "gdata/wd9", "gdata/rp23"],
 )

--- a/src/benchcab/utils/pbs.py
+++ b/src/benchcab/utils/pbs.py
@@ -32,7 +32,7 @@ def render_job_script(
     between model output files.
     """
     verbose_flag = " -v" if verbose else ""
-    storage_flags = ["gdata/ks32", "gdata/hh5", "gdata/wd9", *pbs_config["storage"]]
+    storage_flags = ["gdata/ks32", "gdata/xp65", "gdata/wd9", *pbs_config["storage"]]
 
     context = dict(
         verbose_flag=verbose_flag,

--- a/tests/test_benchcab.py
+++ b/tests/test_benchcab.py
@@ -15,13 +15,13 @@ def _set_user_projects():
         "os.getgroups"
     ) as mocked_groups:
         type(mocked_getgrid.return_value).gr_name = mock.PropertyMock(
-            return_value="hh5"
+            return_value="xp65"
         )
         mocked_groups.return_value = [1]
         yield
 
 
-@pytest.fixture(scope="module", params=["hh5", "invalid_project_name"])
+@pytest.fixture(scope="module", params=["xp65", "invalid_project_name"])
 def config_project(request):
     """Get config project name."""
     return request.param
@@ -42,7 +42,7 @@ no_project_name_msg = re.escape(
 @pytest.mark.parametrize(
     ("config_project", "pytest_error"),
     [
-        ("hh5", does_not_raise()),
+        ("xp65", does_not_raise()),
         (None, pytest.raises(AttributeError, match=no_project_name_msg)),
     ],
 )
@@ -57,7 +57,7 @@ def test_project_name(config_project, pytest_error):
 @pytest.mark.parametrize(
     ("config_project", "pytest_error"),
     [
-        ("hh5", does_not_raise()),
+        ("xp65", does_not_raise()),
         ("invalid_project_name", pytest.raises(PermissionError)),
     ],
 )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,7 +13,7 @@ import benchcab.internal as bi
 import benchcab.utils as bu
 from benchcab import internal
 
-NO_OPTIONAL_CONFIG_PROJECT = "hh5"
+NO_OPTIONAL_CONFIG_PROJECT = "xp65"
 OPTIONAL_CONFIG_PROJECT = "ks32"
 
 
@@ -75,7 +75,7 @@ def all_optional_default_config(no_optional_config) -> dict:
             "experiment": bi.FLUXSITE_DEFAULT_EXPERIMENT,
             "multiprocess": bi.FLUXSITE_DEFAULT_MULTIPROCESS,
             "pbs": bi.FLUXSITE_DEFAULT_PBS,
-            "meorg_model_output_id": bi.FLUXSITE_DEFAULT_MEORG_MODEL_OUTPUT_ID
+            "meorg_model_output_id": bi.FLUXSITE_DEFAULT_MEORG_MODEL_OUTPUT_ID,
         },
         "science_configurations": bi.DEFAULT_SCIENCE_CONFIGURATIONS,
         "spatial": {
@@ -107,7 +107,7 @@ def all_optional_custom_config(no_optional_config) -> dict:
                 "walltime": "10:00:00",
                 "storage": ["scratch/$PROJECT"],
             },
-            "meorg_model_output_id": False
+            "meorg_model_output_id": False,
         },
         "science_configurations": [
             {


### PR DESCRIPTION
Changes for the upcoming `xp65` release.

Replaces all `hh5` occurences with `xp65` in source code and documentation.