### PR TITLE
.conda/benchcab-dev.yaml: remove inclusion of mkdocs-requirements.txt

### DIFF
--- a/.conda/benchcab-dev.yaml
+++ b/.conda/benchcab-dev.yaml
@@ -26,4 +26,7 @@ dependencies:
   - black
   - ruff
   - pip:
-    - -r mkdocs-requirements.txt
+    - mkdocs>1.1
+    - mkdocs-material>=7.2.6
+    - mkdocs-git-revision-date-localized-plugin
+    - mkdocs-macros-plugin


### PR DESCRIPTION
This is work around for initialising pixi environments from benchcab-dev.yaml. Pixi has problems handling the -r input when setting up the environment via `pixi init --import $(realpath $HOME/benchcab)/.conda/benchcab-dev.yaml`:

```
Error:   × Can't parse '-r mkdocs-requirements.txt' as pypi dependency
  ╰─▶ Expected package name starting with an alphanumeric character, found `-`
      -r mkdocs-requirements.txt
      ^
```