### PR TITLE
Remove OPAL_PREFIX from build environment

### DIFF
--- a/src/benchcab/model.py
+++ b/src/benchcab/model.py
@@ -175,6 +175,10 @@ class Model:
                     "-DCMAKE_VERBOSE_MAKEFILE=ON",
                 ]
 
+                # This is required to prevent CMake from finding openmpi
+                # libraries installed under xp65:
+                env.pop("OPAL_PREFIX", None)
+
                 # This is required to prevent CMake from finding the conda
                 # installation of netcdf-fortran (#279):
                 env.pop("LDFLAGS", None)


### PR DESCRIPTION
Recent changes to the xp65 environment [ACCESS-NRI/ACCESS-Analysis-Conda#352](https://github.com/ACCESS-NRI/ACCESS-Analysis-Conda/pull/352) is causing CMake to pick up the wrong MPI library (`/g/data/xp65/public/apps/openmpi/4.1.6` instead of `/apps/openmpi/4.1.0`). The `OPAL_PREFIX` environment variable causes the xp65 MPI library to take precedence over any MPI libraries loaded via module load - as a workaround, this change unsets this variable from the build environment to fix this issue.