### PR TITLE
342 benchcab sub command for do meorg

### DIFF
--- a/src/benchcab/benchcab.py
+++ b/src/benchcab/benchcab.py
@@ -453,3 +453,36 @@ class Benchcab:
         self.spatial_setup_work_directory(config_path)
         self.fluxsite_submit_job(config_path, skip)
         self.spatial_run_tasks(config_path)
+
+    def meorg_transfer(self, config_path: str):
+        """Endpoint for `benchcab meorg-transfer`"""
+
+        # Get a logger, load the config
+        logger = self._get_logger()
+        logger.setLevel(logging.DEBUG)
+        config = self._get_config(config_path)
+
+        # Check to ensure the tasks are complete
+        logger.debug("Checking task completion")
+        tasks = self._get_fluxsite_tasks(config)
+        num_tasks, num_complete, num_failed, all_complete = task_summary(tasks)
+        logger.debug(f"{num_complete}/{num_tasks} completed.")
+
+        # Bail out if incomplete
+        if not all_complete:
+            logger.error(f"{num_failed} tasks have failed, unable to transfer. Exiting.")
+            sys.exit(1)
+
+        # Check if the output name is set
+        if config.get("meorg_output_name") is None:
+            logger.error("meorg_output_name is not defined in config, unable to transfer files.")
+            sys.exit(1)
+
+        # Upload to meorg if meorg_output_name optional key is passed
+        logger.info("Submitting job for meorg transfer")
+        bm.do_meorg(
+            config,
+            upload_dir=internal.FLUXSITE_DIRS["OUTPUT"],
+            benchcab_bin=str(self.benchcab_exe_path),
+            benchcab_job_id=None,
+        )

--- a/src/benchcab/benchcab.py
+++ b/src/benchcab/benchcab.py
@@ -459,7 +459,6 @@ class Benchcab:
 
         # Get a logger, load the config
         logger = self._get_logger()
-        logger.setLevel(logging.DEBUG)
         config = self._get_config(config_path)
 
         # Check to ensure the tasks are complete

--- a/src/benchcab/cli.py
+++ b/src/benchcab/cli.py
@@ -257,4 +257,14 @@ def generate_parser(app: Benchcab) -> argparse.ArgumentParser:
         add_help=False,
     )
     parser_codecov.set_defaults(func=app.gen_codecov)
+
+    # subcommand: 'benchcab meorg-transfer'
+    parser_meorg_transfer = subparsers.add_parser(
+        "meorg-transfer",
+        parents=[args_help, args_subcommand],
+        help="Manually transfer model outputs to modelevaluation.org",
+        add_help=False
+    )
+    parser_meorg_transfer.set_defaults(func=app.meorg_transfer)
+
     return main_parser


### PR DESCRIPTION
Implemented the `meorg-transfer` subcommand.

I note that there are no real tests for the meorg components of benchcab, so here are the outputs from these efforts after having run the vanilla `bench_example` with the following config:

```yaml
realisations:
  - repo:
      git:
        branch: main
    meorg_output_name: True
    name: 123-test

modules: [
  intel-compiler/2021.1.1,
  netcdf/4.7.4,
  openmpi/4.1.0
]

fluxsite:
  pbs:
    storage: [scratch/tm70]
```

Note, `scratch/tm70` was added because that is where I have `pixi` installed for development.

Stdout (after successful `benchcab run` on `bench_example` with no upload):

```
(benchcab-dev) (base) [REDACTED@gadi-login-07 bench_example]$ benchcab meorg-transfer
2026-02-25 11:52:16,587 - DEBUG - benchcab.benchcab.py:466 - Checking task completion
2026-02-25 11:52:16,724 - DEBUG - benchcab.benchcab.py:469 - 168/168 completed.
2026-02-25 11:52:16,724 - INFO - benchcab.benchcab.py:477 - Submitting job for meorg transfer
2026-02-25 11:52:16,724 - DEBUG - meorg.meorg.py:50 - Inferring meorg bin from /scratch/tm70/REDACTED/pixi_cache/envs/benchcab-dev-10170176265764084219/envs/default/bin/benchcab
2026-02-25 11:52:16,725 - DEBUG - meorg.meorg.py:55 - meorg_bin = /scratch/tm70/REDACTED/pixi_cache/envs/benchcab-dev-10170176265764084219/envs/default/bin/meorg
2026-02-25 11:52:16,726 - INFO - meorg.meorg.py:86 - Uploading outputs to modelevaluation.org
2026-02-25 11:52:16,960 - INFO - meorg.meorg.py:121 - Upload job submitted: 161549238.gadi-pbs
```

PBS:

```
PBS Job Id: 161549238.gadi-pbs
Job Name:   meorg_jobscript_WGGXACAG.j2
Execution terminated
Exit_status=0
resources_used.cpupercent=10
resources_used.cput=00:00:38
resources_used.jobfs=0b
resources_used.mem=7753360kb
resources_used.ncpus=1
resources_used.vmem=7753360kb
resources_used.walltime=00:10:54
```

Outputs uploaded to: https://modelevaluation.org/modelOutput/display/kWaGuDaP2qHpknpF9

In addressing this issue, there were problems identified with the docs. These have been raised in #343.

Feel free to ask any questions.

