### PR TITLE
Remove escaped braces from clean help text

### DIFF
--- a/src/benchcab/cli.py
+++ b/src/benchcab/cli.py
@@ -231,7 +231,7 @@ def generate_parser(app: Benchcab) -> argparse.ArgumentParser:
         help="Cleanup files created by running benchcab.",
         description="""Removes src/ and runs/ directories, along with log files in the 
         project root directory. The user has to specify which stage of files to remove 
-        via \{all, realisations, submissions\} subcommand.""",
+        via {all, realisations, submissions} subcommand.""",
         add_help=False,
     )
 


### PR DESCRIPTION
## Summary
- Remove unnecessary backslashes before `{all, realisations, submissions}` in the `benchcab clean` description.
- Keep the rendered CLI help text unchanged while avoiding the Python 3.12+ invalid escape warning from `src/benchcab/cli.py`.

Addresses the benchcab warning reported in #339.

## Validation
- Not run locally.