### PR TITLE
Update readthedocs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
-    python: "3.9"
+    python: "3.13"
 
 mkdocs:
   configuration: mkdocs.yml


### PR DESCRIPTION
## Overview
The readthedocs build for this documentation fails with:

> Config file validation error: Config validation error in build.os. Expected one of (ubuntu-22.04, ubuntu-24.04, ubuntu-26.04, ubuntu-lts-latest), got type str (ubuntu-20.04). Double check the type of the value. A string may be required (e.g. "3.10" instead of 3.10)

because the ubuntu version 20.04 is not supported anymore. 

Updated the readthedocs config to:
- [x] Bump ubuntu to version 24.04
- [x] Bump python to version 3.13