### PR TITLE
Update meorg_client to 0.6.2

### DIFF
--- a/.conda/benchcab-dev.yaml
+++ b/.conda/benchcab-dev.yaml
@@ -17,7 +17,7 @@ dependencies:
   - gitpython
   - jinja2
   - hpcpy>=0.5.0
-  - meorg_client>=0.5.0
+  - meorg_client>=0.6.2
   # CI
   - pytest-cov
   # Dev Dependencies

--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -30,4 +30,4 @@ requirements:
         - gitpython
         - jinja2
         - hpcpy>=0.5.0
-        - meorg_client>=0.5.0
+        - meorg_client>=0.6.2


### PR DESCRIPTION
The [0.6.2 release](https://github.com/ACCESS-NRI/meorg_client/releases/tag/0.6.2) contains a necessary update to register a new model output on modelevaluation.org.