### PR TITLE
.github/workflows/cd.yaml: Update conda publish action to ACCESS-NRI fork

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -34,7 +34,7 @@ jobs:
                 - nodefaults
             EOF
       - name: Build and upload the conda packages
-        uses: uibcdf/action-build-and-upload-conda-packages@v1.2.0
+        uses: ACCESS-NRI/action-build-and-upload-conda-packages@v3.1.0
         with:
           python-version: '3.9'
           meta_yaml_dir: .conda


### PR DESCRIPTION
[action-build-and-upload-conda-packages@v3.1.0](https://github.com/ACCESS-NRI/action-build-and-upload-conda-packages/releases/tag/v3.1.0) contains fixes for the `conda build` failures in the current deployment action. See https://github.com/ACCESS-NRI/action-build-and-upload-conda-packages/issues/9 for more details.